### PR TITLE
expose webrtc version for android (#6)

### DIFF
--- a/sdk/android/BUILD.gn
+++ b/sdk/android/BUILD.gn
@@ -156,6 +156,8 @@ if (is_android) {
     sources = [
       "api/org/webrtc/Predicate.java",
       "api/org/webrtc/RefCounted.java",
+      "api/org/webrtc/WebrtcBuildVersion.java",
+      "src/java/org/webrtc/ApplicationContextProvider.java",
       "src/java/org/webrtc/CalledByNative.java",
       "src/java/org/webrtc/CalledByNativeUnchecked.java",
       "src/java/org/webrtc/Histogram.java",


### PR DESCRIPTION
(cherry picked from commit fcb7b09f454a31b19bc641c576c84cac79024e70)

Patch origin:
https://github.com/shiguredo-webrtc-build/webrtc-build/blob/master/patches/android_webrtc_version.patch