### PR TITLE
Properly remove observer upon deconstruction (#8)

### DIFF
--- a/pc/video_rtp_receiver.cc
+++ b/pc/video_rtp_receiver.cc
@@ -50,6 +50,8 @@ VideoRtpReceiver::VideoRtpReceiver(
 VideoRtpReceiver::~VideoRtpReceiver() {
   RTC_DCHECK_RUN_ON(&signaling_thread_checker_);
   RTC_DCHECK(!media_channel_);
+
+  track_->UnregisterObserver(this);
 }
 
 std::vector<std::string> VideoRtpReceiver::stream_ids() const {


### PR DESCRIPTION
(cherry picked from commit 829f35172de3de761b410b2d2e8ab81d08d72741)

Patch origin:
https://github.com/webrtc-sdk/webrtc/pull/26.patch