### PR TITLE
Add H264 hardware decoding for Marvell chips

### DIFF
--- a/sdk/android/src/java/org/webrtc/MediaCodecUtils.java
+++ b/sdk/android/src/java/org/webrtc/MediaCodecUtils.java
@@ -27,6 +27,7 @@ class MediaCodecUtils {
   // Prefixes for supported hardware encoder/decoder component names.
   static final String EXYNOS_PREFIX = "OMX.Exynos.";
   static final String INTEL_PREFIX = "OMX.Intel.";
+  static final String MARVELL_PREFIX = "OMX.Marvell.";
   static final String NVIDIA_PREFIX = "OMX.Nvidia.";
   static final String QCOM_PREFIX = "OMX.qcom.";
   static final String[] SOFTWARE_IMPLEMENTATION_PREFIXES = {
@@ -46,7 +47,8 @@ class MediaCodecUtils {
       MediaCodecUtils.COLOR_QCOM_FORMATYVU420PackedSemiPlanar32m4ka,
       MediaCodecUtils.COLOR_QCOM_FORMATYVU420PackedSemiPlanar16m4ka,
       MediaCodecUtils.COLOR_QCOM_FORMATYVU420PackedSemiPlanar64x32Tile2m8ka,
-      MediaCodecUtils.COLOR_QCOM_FORMATYUV420PackedSemiPlanar32m};
+      MediaCodecUtils.COLOR_QCOM_FORMATYUV420PackedSemiPlanar32m,
+      MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible};
 
   // Color formats supported by hardware encoder - in order of preference.
   static final int[] ENCODER_COLOR_FORMATS = {

--- a/sdk/android/src/java/org/webrtc/MediaCodecVideoDecoderFactory.java
+++ b/sdk/android/src/java/org/webrtc/MediaCodecVideoDecoderFactory.java
@@ -11,6 +11,7 @@
 package org.webrtc;
 
 import static org.webrtc.MediaCodecUtils.EXYNOS_PREFIX;
+import static org.webrtc.MediaCodecUtils.MARVELL_PREFIX;
 import static org.webrtc.MediaCodecUtils.QCOM_PREFIX;
 
 import android.media.MediaCodecInfo;
@@ -127,8 +128,8 @@ class MediaCodecVideoDecoderFactory implements VideoDecoderFactory {
 
   private boolean isH264HighProfileSupported(MediaCodecInfo info) {
     String name = info.getName();
-    // Support H.264 HP decoding on QCOM chips.
-    if (name.startsWith(QCOM_PREFIX)) {
+    // Support H.264 HP decoding on QCOM and Marvell chips
+    if (name.startsWith(QCOM_PREFIX) || name.startsWith(MARVELL_PREFIX)) {
       return true;
     }
     // Support H.264 HP decoding on Exynos chips for Android M and above.


### PR DESCRIPTION
### 🎯 Goal
Add support for H264 hardware decoding on Bouygues Telecom's AndroidTV boxes relying on Marvell chips.

### 🛠 Implementation details
- Add `MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible` to `MediaCodecUtils.DECODER_COLOR_FORMATS`
- Claim `MediaCodecVideoDecoderFactory.isH264HighProfileSupported()` returns `true` for Marvell chips

### ✍️ Explain examples
Sorry, example code is proprietary.

### Preparing a pull request for review
spotlessApply is OK