### PR TITLE
[Fix]Audio processing pipeline with custom delegate

### DIFF
--- a/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
+++ b/sdk/objc/components/audio/RTCAudioCustomProcessingAdapter.mm
@@ -115,6 +115,7 @@ class AudioCustomProcessingAdapter : public webrtc::CustomProcessing {
     _adapter = new webrtc::AudioCustomProcessingAdapter();
     RTC_LOG(LS_INFO) << "RTCAudioCustomProcessingAdapter init";
   }
+  [self setAudioCustomProcessingDelegate:audioCustomProcessingDelegate];
 
   return self;
 }


### PR DESCRIPTION
Adding the missing delegate wiring which causes the AudioFilters on iOS to fail.