### PR TITLE
[Enhancement]Stereo playout iOS

### DIFF
--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -217,6 +217,7 @@ class AudioDeviceObserver {
   virtual void OnDevicesUpdated() {}
   virtual void OnSpeechActivityEvent(AudioDeviceModule::SpeechActivityEvent event) {}
   virtual void OnStereoUpdatedPlayoutAvailable(bool available) {}
+  virtual void OnStereoUpdatedPlayoutEnabled(bool enabled) {}
 
   // AVAudioEngine lifecycle
   virtual int32_t OnEngineDidCreate(AVAudioEngine* engine) { return 0; }

--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -216,6 +216,7 @@ class AudioDeviceObserver {
   // input/output devices updated or default device changed
   virtual void OnDevicesUpdated() {}
   virtual void OnSpeechActivityEvent(AudioDeviceModule::SpeechActivityEvent event) {}
+  virtual void OnStereoUpdatedPlayoutAvailable(bool available) {}
 
   // AVAudioEngine lifecycle
   virtual int32_t OnEngineDidCreate(AVAudioEngine* engine) { return 0; }

--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -209,6 +209,13 @@ class AudioDeviceModuleForTest : public AudioDeviceModule {
   virtual int SetRecordingSampleRate(uint32_t sample_rate) = 0;
 };
 
+struct AudioProcessingState {
+  bool voice_processing_enabled = false;
+  bool voice_processing_bypassed = false;
+  bool voice_processing_agc_enabled = false;
+  bool stereo_playout_enabled = false;
+};
+
 class AudioDeviceObserver {
  public:
   virtual ~AudioDeviceObserver() = default;
@@ -257,6 +264,9 @@ class AudioDeviceObserver {
                                             NSDictionary* context) {
     return 0;
   }
+
+  virtual void OnAudioProcessingStateChanged(const AudioProcessingState& state) {}
+
 };
 
 }  // namespace webrtc

--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -121,6 +121,9 @@ class AudioDeviceModule : public webrtc::RefCountInterface {
   virtual int32_t StartRecording() = 0;
   virtual int32_t StopRecording() = 0;
   virtual bool Recording() const = 0;
+  // Optional convenience hook for implementations that expose a combined reset.
+  // Defaults to -1 for modules that don't support it.
+  virtual int32_t Reset() { return -1; }
 
   // Audio mixer initialization
   virtual int32_t InitSpeaker() = 0;

--- a/audio/voip/voip_core.cc
+++ b/audio/voip/voip_core.cc
@@ -97,9 +97,9 @@ bool VoipCore::InitializeIfNeeded() {
   bool available = false;
   if (audio_device_module_->StereoPlayoutIsAvailable(&available) != 0) {
     RTC_LOG(LS_WARNING) << "Unable to query stereo playout.";
-  }
-  if (audio_device_module_->SetStereoPlayout(available) != 0) {
-    RTC_LOG(LS_WARNING) << "Unable to set mono/stereo playout mode.";
+  } else if (available) {
+    RTC_LOG(LS_INFO)
+        << "Stereo playout is available; waiting for client to enable it explicitly.";
   }
 
   // Set number of channels on recording device.

--- a/media/engine/adm_helpers.cc
+++ b/media/engine/adm_helpers.cc
@@ -53,8 +53,8 @@ void Init(AudioDeviceModule* adm) {
     if (adm->StereoPlayoutIsAvailable(&available) != 0) {
       RTC_LOG(LS_ERROR) << "Failed to query stereo playout.";
     }
-    if (adm->SetStereoPlayout(available) != 0) {
-      RTC_LOG(LS_ERROR) << "Failed to set stereo playout mode.";
+    if (available) {
+      RTC_LOG(LS_INFO) << "Stereo playout is available; waiting for client to enable it explicitly.";
     }
   }
 

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -334,6 +334,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t SetVoiceProcessingAGCEnabled(bool enable);
   int32_t VoiceProcessingAGCEnabled(bool* enabled);
 
+  void SetManualRestoreVoiceProcessingOnMono(bool manual_restore);
+  bool ManualRestoreVoiceProcessingOnMono() const;
+
   int32_t InitAndStartRecording();
 
  private:
@@ -454,6 +457,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   bool stereo_voice_processing_override_active_ = false;
   bool stereo_saved_voice_processing_enabled_ = true;
   bool stereo_saved_voice_processing_bypassed_ = false;
+  bool manual_restore_voice_processing_on_mono_ = false;
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -137,6 +137,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool advanced_ducking = true;
     long ducking_level = 0;  // 0 = Default
 
+    bool stereo_playout_enabled = false;
+
     uint32_t output_device_id = 0;  // kAudioObjectUnknown
     uint32_t input_device_id = 0;   // kAudioObjectUnknown
 
@@ -154,6 +156,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              voice_processing_bypassed == rhs.voice_processing_bypassed &&
              voice_processing_agc_enabled == rhs.voice_processing_agc_enabled &&
              advanced_ducking == rhs.advanced_ducking && ducking_level == rhs.ducking_level &&
+             stereo_playout_enabled == rhs.stereo_playout_enabled &&
              output_device_id == rhs.output_device_id && input_device_id == rhs.input_device_id &&
              default_output_device_update_count == rhs.default_output_device_update_count &&
              default_input_device_update_count == rhs.default_input_device_update_count;
@@ -190,6 +193,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool IsAllRunning() const {
       return IsOutputInputLinked() ? input_running : input_running && output_running;
     }
+
+    uint32_t DesiredOutputChannels() const { return stereo_playout_enabled ? 2u : 1u; }
 
     bool IsOutputDefaultDevice() const {
 #if TARGET_OS_OSX
@@ -359,6 +364,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              (prev.IsOutputEnabled() != next.IsOutputEnabled());
     }
 
+    bool DidUpdateOutputChannels() const {
+      return prev.DesiredOutputChannels() != next.DesiredOutputChannels();
+    }
+
     bool DidUpdateVoiceProcessingEnabled() const {
       return prev.voice_processing_enabled != next.voice_processing_enabled;
     }
@@ -378,7 +387,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool DidUpdateMuteMode() const { return prev.mute_mode != next.mute_mode; }
 
     bool IsEngineRestartRequired() const {
-      return DidUpdateAudioGraph() ||
+      return DidUpdateAudioGraph() || DidUpdateOutputChannels() ||
              // Voice processing enable state updates
              DidUpdateVoiceProcessingEnabled();
     }
@@ -412,7 +421,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   bool IsMicrophonePermissionGranted();
   int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
-  int32_t ApplyDeviceEngineState(EngineStateUpdate state);
+  int32_t ApplyDeviceEngineState(EngineStateUpdate state,
+                                 bool* stereo_playout_reset = nullptr,
+                                 bool* restore_voice_processing = nullptr);
   int32_t ApplyManualEngineState(EngineStateUpdate state);
 
   // AudioEngine observer methods. May be called from any thread.
@@ -438,6 +449,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 #endif
 
   void DebugAudioEngine();
+  bool RouteSupportsStereo() const;
+
+  bool stereo_voice_processing_override_active_ = false;
+  bool stereo_saved_voice_processing_enabled_ = true;
+  bool stereo_saved_voice_processing_bypassed_ = false;
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -144,6 +144,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     uint32_t default_input_device_update_count = 0;
 
     bool prefers_stereo_playout = false;
+    bool stereo_playout_available = false;
     bool stereo_playout_enabled = false;
 
     bool operator==(const EngineState& rhs) const {
@@ -161,6 +162,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              default_output_device_update_count == rhs.default_output_device_update_count &&
              default_input_device_update_count == rhs.default_input_device_update_count &&
              prefers_stereo_playout == rhs.prefers_stereo_playout &&
+             stereo_playout_available == rhs.stereo_playout_available &&
              stereo_playout_enabled == rhs.stereo_playout_enabled;
     }
 
@@ -212,7 +214,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 #endif
     }
 
-    uint32_t DesiredOutputChannels() const { return prefers_stereo_playout ? 2u : 1u; }
+    uint32_t DesiredOutputChannels() const { 
+      return prefers_stereo_playout && stereo_playout_available 
+      ? 2u 
+      : 1u; 
+    }
   };
 
   explicit AudioEngineDevice(bool voice_processing_bypassed);
@@ -338,6 +344,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   int32_t InitAndStartRecording();
 
+  // Stereo Playout helpers
+  void SetManualRestoreVoiceProcessingOnMono(bool manual_restore);
+  void RefreshStereoPlayoutState();
+
  private:
   struct EngineStateUpdate {
     EngineState prev;
@@ -403,7 +413,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
       bool special_case = (prev.IsOutputEnabled() && next.IsOutputEnabled()) &&
                           (prev.IsInputEnabled() && !next.IsInputEnabled());
 
-      return device || default_device || special_case;
+      // When stereo output channels preference changes or stereo playout becomes
+      // unavailable/available.
+      bool output_channels = DidUpdateDesiredOutputChannels();
+
+      return device || default_device || special_case || output_channels;
     }
 
     bool DidEnableManualRenderingMode() const {
@@ -431,6 +445,14 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   // Stereo Playout helpers
   int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;
+  bool ManualRestoreVoiceProcessingOnMono() const;
+  void UpdateVoiceProcessingForStereoState(const EngineState& prev, EngineState& next);
+
+  bool stereo_voice_processing_override_active_ = false;
+  bool stereo_saved_voice_processing_enabled_ = true;
+  bool stereo_saved_voice_processing_bypassed_ = false;
+  bool stereo_saved_voice_processing_agc_enabled_ = true;
+  bool manual_restore_voice_processing_on_mono_ = false;
 
 // Device related
 #if TARGET_OS_OSX
@@ -455,6 +477,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;
+
+  void ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
+                                    const EngineStateUpdate& state);
 
   // Thread that this object is created on.
   webrtc::Thread* thread_;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -143,6 +143,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     uint32_t default_output_device_update_count = 0;  // Track default switch count
     uint32_t default_input_device_update_count = 0;
 
+    bool prefers_stereo_playout = false;
+    bool stereo_playout_enabled = false;
+
     bool operator==(const EngineState& rhs) const {
       return input_enabled == rhs.input_enabled && input_running == rhs.input_running &&
              output_enabled == rhs.output_enabled && output_running == rhs.output_running &&
@@ -156,7 +159,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              advanced_ducking == rhs.advanced_ducking && ducking_level == rhs.ducking_level &&
              output_device_id == rhs.output_device_id && input_device_id == rhs.input_device_id &&
              default_output_device_update_count == rhs.default_output_device_update_count &&
-             default_input_device_update_count == rhs.default_input_device_update_count;
+             default_input_device_update_count == rhs.default_input_device_update_count &&
+             prefers_stereo_playout == rhs.prefers_stereo_playout &&
+             stereo_playout_enabled == rhs.stereo_playout_enabled;
     }
 
     bool operator!=(const EngineState& rhs) const { return !(*this == rhs); }
@@ -206,6 +211,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
       return input_device_id == 0;
 #endif
     }
+
+    uint32_t DesiredOutputChannels() const { return prefers_stereo_playout ? 2u : 1u; }
   };
 
   explicit AudioEngineDevice(bool voice_processing_bypassed);
@@ -405,6 +412,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
     bool DidEnableDeviceRenderingMode() const {
       return prev.render_mode != RenderMode::Device && next.render_mode == RenderMode::Device;
+    }
+  
+    bool DidUpdateDesiredOutputChannels() const {
+      return prev.DesiredOutputChannels() != next.DesiredOutputChannels();
     }
   };
 

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -347,8 +347,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t InitAndStartRecording();
 
   // Stereo Playout helpers
-  bool ManualRestoreVoiceProcessingOnMono() const;
-  void SetManualRestoreVoiceProcessingOnMono(bool manual_restore);
   void RefreshStereoPlayoutState();
 
  private:
@@ -450,12 +448,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // Stereo Playout helpers
   int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;
   void UpdateVoiceProcessingForStereoState(EngineStateUpdate& state);
-
-  bool stereo_voice_processing_override_active_ = false;
-  bool stereo_saved_voice_processing_enabled_ = true;
-  bool stereo_saved_voice_processing_bypassed_ = false;
-  bool stereo_saved_voice_processing_agc_enabled_ = true;
-  bool manual_restore_voice_processing_on_mono_ = false;
 
 // Device related
 #if TARGET_OS_OSX

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string>
 
 #include "api/scoped_refptr.h"
 #include "api/sequence_checker.h"
@@ -474,7 +475,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 #endif
 
   void DebugAudioEngine();
-  void DebugEngineState(EngineState state);
+  void DebugEngineState(const std::string& prefix, EngineState state);
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -227,6 +227,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   int32_t Init() override;
   int32_t Terminate() override;
+  int32_t Reset() override;
   bool Initialized() const override;
 
   int32_t InitPlayout() override;
@@ -438,6 +439,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   EngineState engine_state_ RTC_GUARDED_BY(thread_);
 
   bool IsMicrophonePermissionGranted();
+  void ResetEngineState();
   int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
   int32_t ApplyDeviceEngineState(EngineStateUpdate& state);
   int32_t ApplyManualEngineState(EngineStateUpdate& state);

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -345,6 +345,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t InitAndStartRecording();
 
   // Stereo Playout helpers
+  bool ManualRestoreVoiceProcessingOnMono() const;
   void SetManualRestoreVoiceProcessingOnMono(bool manual_restore);
   void RefreshStereoPlayoutState();
 
@@ -445,7 +446,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   // Stereo Playout helpers
   int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;
-  bool ManualRestoreVoiceProcessingOnMono() const;
   void UpdateVoiceProcessingForStereoState(const EngineState& prev, EngineState& next);
 
   bool stereo_voice_processing_override_active_ = false;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -418,6 +418,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 
+  // Stereo Playout helpers
+  int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;
+
 // Device related
 #if TARGET_OS_OSX
   static OSStatus objectListenerProc(AudioObjectID objectId, UInt32 numberAddresses,

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -390,12 +390,13 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool DidUpdateMuteMode() const { return prev.mute_mode != next.mute_mode; }
 
     bool IsEngineRestartRequired() const {
-      return DidUpdateAudioGraph() || DidUpdateOutputChannels() ||
+      return DidUpdateAudioGraph() ||
              // Voice processing enable state updates
              DidUpdateVoiceProcessingEnabled();
     }
 
     bool IsEngineRecreateRequired() const {
+      bool didUpdateOutputChannels = DidUpdateOutputChannels();
       // Device id specified
       bool device = DidUpdateOutputDevice() || DidUpdateInputDevice();
 
@@ -408,7 +409,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
       bool special_case = (prev.IsOutputEnabled() && next.IsOutputEnabled()) &&
                           (prev.IsInputEnabled() && !next.IsInputEnabled());
 
-      return device || default_device || special_case;
+      return didUpdateOutputChannels || device || default_device || special_case;
     }
 
     bool DidEnableManualRenderingMode() const {
@@ -457,6 +458,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   bool stereo_voice_processing_override_active_ = false;
   bool stereo_saved_voice_processing_enabled_ = true;
   bool stereo_saved_voice_processing_bypassed_ = false;
+  bool stereo_saved_voice_processing_agc_enabled_ = true;
   bool manual_restore_voice_processing_on_mono_ = false;
 
   void StartRenderLoop();

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -137,8 +137,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool advanced_ducking = true;
     long ducking_level = 0;  // 0 = Default
 
-    bool stereo_playout_enabled = false;
-
     uint32_t output_device_id = 0;  // kAudioObjectUnknown
     uint32_t input_device_id = 0;   // kAudioObjectUnknown
 
@@ -156,7 +154,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              voice_processing_bypassed == rhs.voice_processing_bypassed &&
              voice_processing_agc_enabled == rhs.voice_processing_agc_enabled &&
              advanced_ducking == rhs.advanced_ducking && ducking_level == rhs.ducking_level &&
-             stereo_playout_enabled == rhs.stereo_playout_enabled &&
              output_device_id == rhs.output_device_id && input_device_id == rhs.input_device_id &&
              default_output_device_update_count == rhs.default_output_device_update_count &&
              default_input_device_update_count == rhs.default_input_device_update_count;
@@ -193,8 +190,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool IsAllRunning() const {
       return IsOutputInputLinked() ? input_running : input_running && output_running;
     }
-
-    uint32_t DesiredOutputChannels() const { return stereo_playout_enabled ? 2u : 1u; }
 
     bool IsOutputDefaultDevice() const {
 #if TARGET_OS_OSX
@@ -334,9 +329,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t SetVoiceProcessingAGCEnabled(bool enable);
   int32_t VoiceProcessingAGCEnabled(bool* enabled);
 
-  void SetManualRestoreVoiceProcessingOnMono(bool manual_restore);
-  bool ManualRestoreVoiceProcessingOnMono() const;
-
   int32_t InitAndStartRecording();
 
  private:
@@ -367,10 +359,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
              (prev.IsOutputEnabled() != next.IsOutputEnabled());
     }
 
-    bool DidUpdateOutputChannels() const {
-      return prev.DesiredOutputChannels() != next.DesiredOutputChannels();
-    }
-
     bool DidUpdateVoiceProcessingEnabled() const {
       return prev.voice_processing_enabled != next.voice_processing_enabled;
     }
@@ -396,7 +384,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     }
 
     bool IsEngineRecreateRequired() const {
-      bool didUpdateOutputChannels = DidUpdateOutputChannels();
       // Device id specified
       bool device = DidUpdateOutputDevice() || DidUpdateInputDevice();
 
@@ -409,7 +396,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
       bool special_case = (prev.IsOutputEnabled() && next.IsOutputEnabled()) &&
                           (prev.IsInputEnabled() && !next.IsInputEnabled());
 
-      return didUpdateOutputChannels || device || default_device || special_case;
+      return device || default_device || special_case;
     }
 
     bool DidEnableManualRenderingMode() const {
@@ -425,9 +412,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   bool IsMicrophonePermissionGranted();
   int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
-  int32_t ApplyDeviceEngineState(EngineStateUpdate state,
-                                 bool* stereo_playout_reset = nullptr,
-                                 bool* restore_voice_processing = nullptr);
+  int32_t ApplyDeviceEngineState(EngineStateUpdate state);
   int32_t ApplyManualEngineState(EngineStateUpdate state);
 
   // AudioEngine observer methods. May be called from any thread.
@@ -453,13 +438,6 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 #endif
 
   void DebugAudioEngine();
-  bool RouteSupportsStereo() const;
-
-  bool stereo_voice_processing_override_active_ = false;
-  bool stereo_saved_voice_processing_enabled_ = true;
-  bool stereo_saved_voice_processing_bypassed_ = false;
-  bool stereo_saved_voice_processing_agc_enabled_ = true;
-  bool manual_restore_voice_processing_on_mono_ = false;
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -215,7 +215,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     }
 
     uint32_t DesiredOutputChannels() const { 
-      return prefers_stereo_playout && stereo_playout_available 
+      return prefers_stereo_playout && stereo_playout_available && input_muted
       ? 2u 
       : 1u; 
     }
@@ -438,15 +438,15 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   bool IsMicrophonePermissionGranted();
   int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
-  int32_t ApplyDeviceEngineState(EngineStateUpdate state);
-  int32_t ApplyManualEngineState(EngineStateUpdate state);
+  int32_t ApplyDeviceEngineState(EngineStateUpdate& state);
+  int32_t ApplyManualEngineState(EngineStateUpdate& state);
 
   // AudioEngine observer methods. May be called from any thread.
   void ReconfigureEngine();
 
   // Stereo Playout helpers
   int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;
-  void UpdateVoiceProcessingForStereoState(const EngineState& prev, EngineState& next);
+  void UpdateVoiceProcessingForStereoState(EngineStateUpdate& state);
 
   bool stereo_voice_processing_override_active_ = false;
   bool stereo_saved_voice_processing_enabled_ = true;
@@ -474,12 +474,18 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 #endif
 
   void DebugAudioEngine();
+  void DebugEngineState(EngineState state);
 
   void StartRenderLoop();
   AVAudioEngineManualRenderingBlock render_block_;
 
   void ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
-                                    const EngineStateUpdate& state);
+                                    EngineStateUpdate state);
+
+  void ConfigureMutedSpeechActivityEventListener(AVAudioInputNode* input_node, 
+                                                 EngineStateUpdate state);
+
+  void NotifyProcessingStateObserver(EngineStateUpdate state);
 
   // Thread that this object is created on.
   webrtc::Thread* thread_;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -678,6 +678,12 @@ bool AudioEngineDevice::RouteSupportsStereo() const {
 #if defined(WEBRTC_IOS)
   AVAudioSession* session = [AVAudioSession sharedInstance];
   NSString* mode = session.mode;
+  AVAudioSessionRouteDescription* current_route = session.currentRoute;
+  NSString* route_description = current_route.description;
+
+  LOGI() << "RouteSupportsStereo: current_route ("
+         << (route_description ? route_description.UTF8String : "unknown") << ")";
+  LOGI() << "RouteSupportsStereo: mode active (" << [mode UTF8String] << ")";
 
   static NSArray<NSString*>* const kMonoModes = @[
     AVAudioSessionModeVoiceChat,
@@ -767,6 +773,10 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
     if (stereo_voice_processing_override_active_) {
       stereo_voice_processing_override_active_ = false;
     }
+  }
+
+  if (observer_ != nullptr) {
+    observer_->OnStereoUpdatedPlayoutEnabled(enable);
   }
 
   return 0;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -661,6 +661,10 @@ int32_t AudioEngineDevice::StereoPlayoutIsAvailable(bool* available) const {
 
   *available = available_value;
 
+  if (observer_ != nullptr) {
+    observer_->OnStereoUpdatedPlayoutAvailable(available_value);
+  }
+
   LOGI() << "StereoPlayoutIsAvailable: " << *available << " (render mode allows: "
          << render_mode_allows_stereo
          << ", route supports: " << route_supports_stereo << ")";

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -20,6 +20,7 @@
 #include "audio_engine_device.h"
 
 #include <mach/mach_time.h>
+#include <algorithm>
 #include <cmath>
 
 #include "api/array_view.h"
@@ -86,6 +87,9 @@ AudioEngineDevice::AudioEngineDevice(bool voice_processing_bypassed)
 
   // Initial engine state
   engine_state_.voice_processing_bypassed = voice_processing_bypassed;
+  stereo_voice_processing_override_active_ = false;
+  stereo_saved_voice_processing_enabled_ = true;
+  stereo_saved_voice_processing_bypassed_ = false;
 }
 
 AudioEngineDevice::~AudioEngineDevice() {
@@ -645,30 +649,136 @@ int32_t AudioEngineDevice::MicrophoneMute(bool* enabled) const {
 
 int32_t AudioEngineDevice::StereoPlayoutIsAvailable(bool* available) const {
   LOGI() << "StereoPlayoutIsAvailable";
+  RTC_DCHECK_RUN_ON(thread_);
+
   if (available == nullptr) {
     return -1;
   }
 
-  *available = false;
+  bool render_mode_allows_stereo = engine_state_.render_mode != RenderMode::Manual;
+  bool route_supports_stereo = RouteSupportsStereo();
+  bool available_value = render_mode_allows_stereo && route_supports_stereo;
+
+  *available = available_value;
+
+  LOGI() << "StereoPlayoutIsAvailable: " << *available << " (render mode allows: "
+         << render_mode_allows_stereo
+         << ", route supports: " << route_supports_stereo << ")";
 
   return 0;
 }
 
-int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
-  LOGW() << "SetStereoPlayout: Not implemented, value:" << enable;
+bool AudioEngineDevice::RouteSupportsStereo() const {
+  RTC_DCHECK_RUN_ON(thread_);
 
-  audio_device_buffer_->SetPlayoutChannels(1);
+#if defined(WEBRTC_IOS)
+  AVAudioSession* session = [AVAudioSession sharedInstance];
+  NSString* mode = session.mode;
+
+  static NSArray<NSString*>* const kMonoModes = @[
+    AVAudioSessionModeVoiceChat,
+    AVAudioSessionModeVideoChat,
+    AVAudioSessionModeGameChat
+  ];
+
+  for (NSString* mono_mode in kMonoModes) {
+    if ([mode isEqualToString:mono_mode]) {
+      LOGI() << "RouteSupportsStereo: Mono mode active (" << [mode UTF8String] << ")";
+      return false;
+    }
+  }
+
+  NSInteger channel_count = session.outputNumberOfChannels;
+  if (channel_count < 2) {
+    AVAudioSessionRouteDescription* route = session.currentRoute;
+    for (AVAudioSessionPortDescription* port in route.outputs) {
+      channel_count = std::max(channel_count, (NSInteger)port.channels.count);
+    }
+  }
+
+  LOGI() << "RouteSupportsStereo channel_count: " << channel_count;
+  return channel_count >= 2;
+#else
+  return true;
+#endif
+}
+
+int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
+  RTC_DCHECK_RUN_ON(thread_);
+  LOGI() << "SetStereoPlayout: " << enable;
+
+  if (engine_state_.stereo_playout_enabled == enable) {
+    return 0;
+  }
+
+  if (engine_state_.render_mode == RenderMode::Manual &&
+      enable != engine_state_.stereo_playout_enabled) {
+    LOGE() << "SetStereoPlayout: Manual rendering mode currently supports mono only";
+    return kAudioEngineManualRenderingError;
+  }
+
+  if (enable) {
+    bool available = false;
+    if (StereoPlayoutIsAvailable(&available) != 0 || !available) {
+      LOGE() << "SetStereoPlayout: Current audio route does not support stereo";
+      return kAudioEngineDeviceFormatError;
+    }
+  }
+
+  const bool vp_enabled_before = engine_state_.voice_processing_enabled;
+  const bool vp_bypassed_before = engine_state_.voice_processing_bypassed;
+  const bool apply_vp_override = enable && vp_enabled_before;
+
+  if (enable && apply_vp_override) {
+    LOGW() << "Stereo playout requested while voice processing enabled; disabling voice processing";
+  }
+
+  int32_t result = ModifyEngineState([this, enable, apply_vp_override](EngineState state) -> EngineState {
+    state.stereo_playout_enabled = enable;
+    if (enable) {
+      if (apply_vp_override) {
+        state.voice_processing_enabled = false;
+        state.voice_processing_bypassed = false;
+      }
+    } else {
+      if (stereo_voice_processing_override_active_) {
+        state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+        state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+      }
+    }
+    return state;
+  });
+
+  if (result != 0) {
+    return result;
+  }
+
+  if (enable) {
+    if (apply_vp_override) {
+      stereo_voice_processing_override_active_ = true;
+      stereo_saved_voice_processing_enabled_ = vp_enabled_before;
+      stereo_saved_voice_processing_bypassed_ = vp_bypassed_before;
+    }
+  } else {
+    if (stereo_voice_processing_override_active_) {
+      stereo_voice_processing_override_active_ = false;
+    }
+  }
 
   return 0;
 }
 
 int32_t AudioEngineDevice::StereoPlayout(bool* enabled) const {
   LOGI() << "StereoPlayout";
+  RTC_DCHECK_RUN_ON(thread_);
+
   if (enabled == nullptr) {
     return -1;
   }
 
-  *enabled = false;
+  *enabled = engine_state_.stereo_playout_enabled;
+
+  LOGI() << "StereoPlayout: " << *enabled;
 
   return 0;
 }
@@ -1130,6 +1240,9 @@ int32_t AudioEngineDevice::SetManualRenderingMode(bool enable) {
 
   int32_t result = ModifyEngineState([enable](EngineState state) -> EngineState {
     state.render_mode = enable ? RenderMode::Manual : RenderMode::Device;
+    if (enable) {
+      state.stereo_playout_enabled = false;
+    }
     return state;
   });
 
@@ -1266,6 +1379,19 @@ void AudioEngineDevice::ReconfigureEngine() {
 
     EngineState current_state = this->engine_state_;
 
+    if (current_state.stereo_playout_enabled) {
+      bool available = false;
+      if (this->StereoPlayoutIsAvailable(&available) == 0 && !available) {
+        LOGW() << "Route change removed stereo support, reverting to mono";
+        current_state.stereo_playout_enabled = false;
+        if (stereo_voice_processing_override_active_) {
+          current_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+          current_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+          stereo_voice_processing_override_active_ = false;
+        }
+      }
+    }
+
     // Re-configure is only for device mode
     if (current_state.render_mode != RenderMode::Device) return;
 
@@ -1307,8 +1433,24 @@ int32_t AudioEngineDevice::ModifyEngineState(
   RTC_DCHECK_RUN_ON(thread_);
 
   EngineState old_state = engine_state_;
-  EngineState new_state = state_transform(old_state);
-  EngineStateUpdate state = {old_state, new_state};
+  EngineStateUpdate state = {old_state, state_transform(old_state)};
+  EngineState& new_state = state.next;
+  bool route_forces_mono = false;
+  bool route_restore_voice_processing = false;
+
+  if (state.next.stereo_playout_enabled && !RouteSupportsStereo()) {
+    LOGW() << "Route does not support stereo, forcing mono";
+    state.next.stereo_playout_enabled = false;
+    route_forces_mono = true;
+    if (stereo_voice_processing_override_active_) {
+      route_restore_voice_processing = true;
+      state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+      state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+    }
+  }
+
+  bool stereo_reset = route_forces_mono;
+  bool restore_voice_processing = route_restore_voice_processing;
 
   // No changes, return immediately.
   if (state.HasNoChanges()) {
@@ -1327,6 +1469,12 @@ int32_t AudioEngineDevice::ModifyEngineState(
     return -1;
   }
 
+  if (new_state.stereo_playout_enabled && new_state.voice_processing_enabled &&
+      !new_state.voice_processing_bypassed) {
+    LOGE() << "ModifyEngineState: Stereo playout requires voice processing to be disabled or bypassed";
+    return kAudioEngineVoiceProcessingError;
+  }
+
   int32_t shutdown_result = 0;
   int32_t startup_result = 0;
 
@@ -1334,7 +1482,10 @@ int32_t AudioEngineDevice::ModifyEngineState(
   if (state.DidEnableManualRenderingMode()) {
     EngineStateUpdate shutdown_state = state;                  // Copy current state
     shutdown_state.next = {};                                  // Reset next state to default
-    shutdown_result = ApplyDeviceEngineState(shutdown_state);  // Shutdown device rendering
+    stereo_reset = false;
+    restore_voice_processing = false;
+    shutdown_result = ApplyDeviceEngineState(shutdown_state, &stereo_reset,
+                                             &restore_voice_processing);  // Shutdown device rendering
     if (shutdown_result != 0) {
       LOGE() << "ModifyEngineState: Failed to shutdown device rendering, error: "
              << shutdown_result;
@@ -1355,12 +1506,17 @@ int32_t AudioEngineDevice::ModifyEngineState(
     }
     EngineStateUpdate startup_state = state;                 // Copy current state
     shutdown_state.prev = {};                                //
-    startup_result = ApplyDeviceEngineState(startup_state);  // Start device mode
+    stereo_reset = false;
+    restore_voice_processing = false;
+    startup_result = ApplyDeviceEngineState(startup_state, &stereo_reset,
+                                            &restore_voice_processing);  // Start device mode
     if (startup_result != 0) {
       LOGE() << "ModifyEngineState: Failed to start device mode, error: " << startup_result;
     }
   } else if (new_state.render_mode == RenderMode::Device) {
-    shutdown_result = ApplyDeviceEngineState(state);
+    stereo_reset = false;
+    restore_voice_processing = false;
+    shutdown_result = ApplyDeviceEngineState(state, &stereo_reset, &restore_voice_processing);
     if (shutdown_result != 0) {
       LOGE() << "ModifyEngineState: Failed to update state in device mode, error: "
              << shutdown_result;
@@ -1377,6 +1533,18 @@ int32_t AudioEngineDevice::ModifyEngineState(
 
   // Additional checks for buffer state.
   if (return_result == 0) {
+    if (stereo_reset && new_state.stereo_playout_enabled) {
+      LOGW() << "Stereo playout disabled due to output route constraints";
+      new_state.stereo_playout_enabled = false;
+    }
+
+    if (restore_voice_processing && stereo_voice_processing_override_active_) {
+      LOGW() << "Restoring voice processing after stereo fallback";
+      new_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+      new_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+      stereo_voice_processing_override_active_ = false;
+    }
+
     // Buffer should be playing if output is running.
     if (new_state.IsOutputEnabled()) {
       RTC_DCHECK(audio_device_buffer_->IsPlaying());
@@ -1633,9 +1801,18 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
   return 0;
 }
 
-int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
+int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
+                                                  bool* stereo_playout_reset,
+                                                  bool* restore_voice_processing) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_manual_input_ == nullptr);
+
+  if (stereo_playout_reset) {
+    *stereo_playout_reset = false;
+  }
+  if (restore_voice_processing) {
+    *restore_voice_processing = false;
+  }
 
   std::vector<std::function<void()>> rollback_actions;
 
@@ -1783,10 +1960,13 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     BOOL set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
                                                           error:&error];
     if (!set_vp_result) {
-      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
-      RTC_DCHECK(set_vp_result);
+      LOGE() << "setVoiceProcessingEnabled (input) failed: "
+             << (error ? error.localizedDescription.UTF8String : "Unknown error");
+      state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
+      state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
     }
-    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
+    LOGI() << "setVoiceProcessingEnabled (input) result: "
+           << (set_vp_result ? "YES" : "NO");
 #endif
 
     if (inputNode().voiceProcessingEnabled) {
@@ -1853,10 +2033,87 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       return rollback(kAudioEnginePlayoutDeviceNotAvailableError);
     }
 
+    AVAudioChannelCount requested_channels =
+        static_cast<AVAudioChannelCount>(state.next.DesiredOutputChannels());
+    AVAudioChannelCount hardware_channels = output_node_format.channelCount;
+
+    if (requested_channels == 0) {
+      requested_channels = 1;
+    }
+
+    if (requested_channels > hardware_channels) {
+      LOGW() << "Requested playout channels " << requested_channels
+             << " exceeds hardware capability " << hardware_channels << ", falling back";
+      requested_channels = std::max<AVAudioChannelCount>(1, hardware_channels);
+      if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
+        *stereo_playout_reset = true;
+      }
+      if (restore_voice_processing && state.next.stereo_playout_enabled &&
+          stereo_voice_processing_override_active_) {
+        *restore_voice_processing = true;
+        state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+        state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+#if !TARGET_OS_SIMULATOR
+        if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+          NSError* vp_error = nil;
+          BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                        error:&vp_error];
+          if (!set_vp) {
+            LOGE() << "Failed to restore voice processing: "
+                   << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
+            state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
+            state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
+            if (restore_voice_processing) {
+              *restore_voice_processing = false;
+            }
+            stereo_voice_processing_override_active_ = false;
+          } else if (state.next.voice_processing_enabled &&
+                     inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
+            inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
+          }
+        } else if (state.next.voice_processing_enabled &&
+                   inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
+          inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
+        }
+#endif
+      }
+    } else if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
+      // Handle cases where desired stereo was set but route currently only reports mono channels.
+      *stereo_playout_reset = true;
+      if (restore_voice_processing && stereo_voice_processing_override_active_) {
+        *restore_voice_processing = true;
+        state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+        state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+#if !TARGET_OS_SIMULATOR
+        if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+          NSError* vp_error = nil;
+          BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                        error:&vp_error];
+          if (!set_vp) {
+            LOGE() << "Failed to restore voice processing: "
+                   << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
+            state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
+            state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
+            if (restore_voice_processing) {
+              *restore_voice_processing = false;
+            }
+            stereo_voice_processing_override_active_ = false;
+          } else if (state.next.voice_processing_enabled &&
+                     inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
+            inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
+          }
+        } else if (state.next.voice_processing_enabled &&
+                   inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
+          inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
+        }
+#endif
+      }
+    }
+
     AVAudioFormat* engine_output_format = [[AVAudioFormat alloc]
         initWithCommonFormat:output_node_format.commonFormat  // Usually float32
                   sampleRate:output_node_format.sampleRate
-                    channels:1
+                    channels:requested_channels
                  interleaved:output_node_format.interleaved];
 
     audio_device_buffer_->SetPlayoutSampleRate(engine_output_format.sampleRate);
@@ -1867,7 +2124,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     AVAudioFormat* rtc_output_format =
         [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
                                          sampleRate:engine_output_format.sampleRate
-                                           channels:1
+                                           channels:requested_channels
                                         interleaved:YES];
 
     AVAudioSourceNodeRenderBlock source_block =
@@ -1878,7 +2135,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
           int16_t* dest_buffer = (int16_t*)outputData->mBuffers[0].mData;
 
           fine_audio_buffer_->GetPlayoutData(
-              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer), frameCount),
+              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer),
+                                         static_cast<size_t>(frameCount) *
+                                             rtc_output_format.channelCount),
               kFixedPlayoutDelayEstimate);
 
           return noErr;
@@ -2319,9 +2578,14 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       }
 
       if (start_result) {
-        RTC_DCHECK(configuration_observer_ == nullptr);
-        // Add observer for configuration changes
         NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+        if (configuration_observer_ != nullptr) {
+          [center removeObserver:(__bridge_transfer id)configuration_observer_
+                            name:AVAudioEngineConfigurationChangeNotification
+                          object:nil];
+          configuration_observer_ = nullptr;
+        }
+
         configuration_observer_ = (__bridge_retained void*)[center
             addObserverForName:AVAudioEngineConfigurationChangeNotification
                         object:engine_device_
@@ -2371,7 +2635,8 @@ void AudioEngineDevice::StartRenderLoop() {
 
   const double sample_rate = manual_render_rtc_format_.sampleRate;
   const size_t frames_per_buffer = static_cast<size_t>(sample_rate / 100);  // 10ms chunks
-  const size_t buffer_size = frames_per_buffer * kAudioSampleSize;
+  const size_t channel_count = static_cast<size_t>(manual_render_rtc_format_.channelCount);
+  const size_t buffer_size = frames_per_buffer * channel_count * kAudioSampleSize;
   const int chunk_ms =
       static_cast<int>(std::round(1000.0 * static_cast<double>(frames_per_buffer) / sample_rate));
   int64_t next_wakeup_ms = rtc::TimeMillis();
@@ -2388,7 +2653,8 @@ void AudioEngineDevice::StartRenderLoop() {
 
     // Call GetPlayoutData to pull frames into rtc audio stack even though we won't use it here.
     fine_audio_buffer_->GetPlayoutData(
-        webrtc::ArrayView<int16_t>(read_rtc_buffer, frames_per_buffer), kFixedPlayoutDelayEstimate);
+        webrtc::ArrayView<int16_t>(read_rtc_buffer, frames_per_buffer * channel_count),
+        kFixedPlayoutDelayEstimate);
 
     // Render (Input)
     RTC_DCHECK(render_buffer_ != nullptr);
@@ -2407,7 +2673,7 @@ void AudioEngineDevice::StartRenderLoop() {
       const int64_t capture_time_ns = capture_time * machTickUnitsToNanoseconds_;
 
       fine_audio_buffer_->DeliverRecordedData(
-          webrtc::ArrayView<const int16_t>(rtc_buffer, frames_per_buffer),
+          webrtc::ArrayView<const int16_t>(rtc_buffer, frames_per_buffer * channel_count),
           kFixedRecordDelayEstimate, capture_time_ns);
     } else {
       LOGW() << "Render error: " << err << " frames: " << frames_per_buffer;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -728,8 +728,8 @@ int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& s
 
   LOGI() << "ResolveStereoPlayoutAvailability {"
          << "currentRoute: "<< (route_description ? route_description.UTF8String : "unknown")
-         << "mode: " << (mode ? mode.UTF8String : "unknown")
-         << "channelCount: " << channel_count
+         << ", mode: " << (mode ? mode.UTF8String : "unknown")
+         << ", channelCount: " << channel_count
          << " }";
 
   *available = true;
@@ -759,8 +759,8 @@ void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restor
 
 void AudioEngineDevice::UpdateVoiceProcessingForStereoState(const EngineState& prev,
                                                             EngineState& next) {
-  const bool enabling_stereo = !prev.stereo_playout_enabled && next.stereo_playout_available;
-  const bool disabling_stereo = prev.stereo_playout_enabled && !next.stereo_playout_available;
+  const bool enabling_stereo = !prev.stereo_playout_enabled && next.stereo_playout_enabled;
+  const bool disabling_stereo = prev.stereo_playout_enabled && !next.stereo_playout_enabled;
 
   if (enabling_stereo) {
     if (!stereo_voice_processing_override_active_) {
@@ -1543,6 +1543,19 @@ int32_t AudioEngineDevice::ModifyEngineState(
         LOGE() << "ModifyEngineState: Buffer should not be recording when input is disabled";
       }
     }
+    
+    AudioProcessingState proc_state;
+    proc_state.voice_processing_enabled = new_state.voice_processing_enabled;
+    proc_state.voice_processing_bypassed = new_state.voice_processing_bypassed;
+    proc_state.voice_processing_agc_enabled = new_state.voice_processing_agc_enabled;
+    proc_state.stereo_playout_enabled = new_state.stereo_playout_enabled;
+
+    if (observer_ && (state.prev.voice_processing_enabled != new_state.voice_processing_enabled ||
+                      state.prev.voice_processing_bypassed != new_state.voice_processing_bypassed ||
+                      state.prev.voice_processing_agc_enabled != new_state.voice_processing_agc_enabled ||
+                      state.prev.stereo_playout_enabled != new_state.stereo_playout_enabled)) {
+      observer_->OnAudioProcessingStateChanged(proc_state);
+    }
 
     // Update engine state if no error
     engine_state_ = new_state;
@@ -1925,11 +1938,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   }
 
   // --------------------------------------------------------------------------------------------
-  // Step: Configure Voice-Processing I/O
-  //
-  ConfigureVoiceProcessingNode(inputNode(), state);
-
-  // --------------------------------------------------------------------------------------------
   // Step: Enable output
   //
   if (state.next.IsOutputEnabled() &&
@@ -2043,7 +2051,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     
     LOGI() << "Updating VoiceProcessing state from the updated output configuration...";
     UpdateVoiceProcessingForStereoState(state.prev, state.next);
-    ConfigureVoiceProcessingNode(inputNode(), state);
 
     if (this->observer_ != nullptr) {
       NSDictionary* context = @{};
@@ -2075,6 +2082,11 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       source_node_ = nil;
     }
   }
+
+  // --------------------------------------------------------------------------------------------
+  // Step: Configure Voice-Processing I/O
+  //
+  ConfigureVoiceProcessingNode(inputNode(), state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Enable input

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -484,7 +484,9 @@ void AudioEngineDevice::OnValidRouteChange() {
   LOGI() << "OnValidRouteChange";
   RTC_DCHECK(thread_);
 
-  RefreshStereoPlayoutState();
+  thread_->PostTask(SafeTask(safety_, [this] {
+    this->RefreshStereoPlayoutState();
+  }));
 }
 
 void AudioEngineDevice::OnCanPlayOrRecordChange(bool can_play_or_record) {
@@ -1436,6 +1438,8 @@ bool AudioEngineDevice::IsMicrophonePermissionGranted() {
 int32_t AudioEngineDevice::ModifyEngineState(
     std::function<EngineState(EngineState)> state_transform) {
   RTC_DCHECK_RUN_ON(thread_);
+
+  LOGI() << "ModifyEngineState [Begin] --------------------------------";
   
   EngineState old_state = engine_state_;
   EngineState new_state = state_transform(old_state);
@@ -1467,21 +1471,53 @@ int32_t AudioEngineDevice::ModifyEngineState(
 
   UpdateVoiceProcessingForStereoState(state);
 
+  // --------------------------------------------------------------------------------------------
+  // Step: Debugging Output
+  //
+  LOGI() << "ModifyEngineState: Plan {"
+         << " HasNoChanges: " << state.HasNoChanges()
+         << ", DidEnableOutput: " << state.DidEnableOutput()
+         << ", DidEnableInput: " << state.DidEnableInput()
+         << ", DidDisableOutput: " << state.DidDisableOutput()
+         << ", DidDisableInput: " << state.DidDisableInput()
+         << ", DidAnyEnable: " << state.DidAnyEnable()
+         << ", DidAnyDisable: " << state.DidAnyDisable()
+         << ", DidBeginInterruption: " << state.DidBeginInterruption()
+         << ", DidEndInterruption: " << state.DidEndInterruption()
+         << ", DidUpdateAudioGraph: " << state.DidUpdateAudioGraph()
+         << ", DidUpdateVoiceProcessingEnabled: " << state.DidUpdateVoiceProcessingEnabled()
+         << ", DidUpdateOutputDevice: " << state.DidUpdateOutputDevice()
+         << ", DidUpdateInputDevice: " << state.DidUpdateInputDevice()
+         << ", DidUpdateDefaultOutputDevice: " << state.DidUpdateDefaultOutputDevice()
+         << ", DidUpdateDefaultInputDevice: " << state.DidUpdateDefaultInputDevice()
+         << ", DidUpdateMuteMode: " << state.DidUpdateMuteMode()
+         << ", IsEngineRestartRequired: " << state.IsEngineRestartRequired()
+         << ", IsEngineRecreateRequired: " << state.IsEngineRecreateRequired()
+         << ", DidEnableManualRenderingMode: " << state.DidEnableManualRenderingMode()
+         << ", DidEnableDeviceRenderingMode: " << state.DidEnableDeviceRenderingMode()
+         << ", DidUpdateDesiredOutputChannels: " << state.DidUpdateDesiredOutputChannels()
+         << " }";
+  DebugEngineState("ModifyEngineState: Old State", state.prev);
+  DebugEngineState("ModifyEngineState: Next State", state.next);
+
   // No changes, return immediately.
   if (state.HasNoChanges()) {
     LOGI() << "ModifyEngineState: No changes";
+    LOGI() << "ModifyEngineState [End] --------------------------------";
     return 0;
   }
 
   // Check input should be enabled if running.
   if (state.next.input_running && !state.next.input_enabled) {
     LOGE() << "ModifyEngineState: Input must be enabled if running";
+    LOGI() << "ModifyEngineState [End] --------------------------------";
     return -1;
   }
 
   // Check output should be enabled if running.
   if (state.next.output_running && !state.next.output_enabled) {
     LOGE() << "ModifyEngineState: Output must be enabled if running";
+    LOGI() << "ModifyEngineState [End] --------------------------------";
     return -1;
   }
 
@@ -1566,9 +1602,13 @@ int32_t AudioEngineDevice::ModifyEngineState(
     
     // Update engine state if no error
     engine_state_ = state.next;
-    LOGI() << "ModifyEngineState: "
-           << (state.IsEngineRecreateRequired() ? "Recreated" : state.IsEngineRestartRequired() ? "Restarted" : "Updated");
-    DebugEngineState(state.next);
+    const char* update_state =
+        state.IsEngineRecreateRequired()
+            ? "Recreated"
+            : (state.IsEngineRestartRequired() ? "Restarted" : "Updated");
+    std::string prefix = std::string("ModifyEngineState: ") + update_state;
+    DebugEngineState(prefix, state.next);
+    LOGI() << "ModifyEngineState [End] --------------------------------";
   }
 
   return return_result;
@@ -2825,12 +2865,20 @@ void AudioEngineDevice::UpdateAllDeviceIDs() {
 // ----------------------------------------------------------------------------------------------------
 // Private - Debug
 
-void AudioEngineDevice::DebugEngineState(EngineState state) {
+void AudioEngineDevice::DebugEngineState(const std::string& prefix,
+                                         EngineState state) {
   RTC_DCHECK_RUN_ON(thread_);
 
-  LOGI() << "EngineState {"
+  LOGI() << prefix << " {"
          << "IsOutputEnabled: " << state.IsOutputEnabled()
          << ", IsInputEnabled: " << state.IsInputEnabled()
+         << ", IsOutputInputLinked: " << state.IsOutputInputLinked()
+         << ", IsOutputRunning: " << state.IsOutputRunning()
+         << ", IsInputRunning: " << state.IsInputRunning()
+         << ", IsAnyEnabled: " << state.IsAnyEnabled()
+         << ", IsAnyRunning: " << state.IsAnyRunning()
+         << ", IsAllEnabled: " << state.IsAllEnabled()
+         << ", IsAllRunning: " << state.IsAllRunning()
          << ", AdvancedDucking: " << state.advanced_ducking
          << ", DuckingLevel: " << state.ducking_level
          << ", MuteMode: " << static_cast<int>(state.mute_mode)

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -644,14 +644,9 @@ int32_t AudioEngineDevice::MicrophoneMute(bool* enabled) const {
 // Stereo Playout
 
 int32_t AudioEngineDevice::StereoPlayoutIsAvailable(bool* available) const {
-  LOGI() << "StereoPlayoutIsAvailable";
-  if (available == nullptr) {
-    return -1;
-  }
+  RTC_DCHECK_RUN_ON(thread_);
 
-  *available = false;
-
-  return 0;
+  return ResolveStereoPlayoutAvailability(engine_state_, available);
 }
 
 int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
@@ -669,6 +664,71 @@ int32_t AudioEngineDevice::StereoPlayout(bool* enabled) const {
   }
 
   *enabled = false;
+
+  return 0;
+}
+
+int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& state,
+                                                            bool* available) const {
+  if (available == nullptr) {
+    return -1;
+  }
+
+  *available = false;
+
+  if (state.render_mode == RenderMode::Manual) {
+    LOGI() << "ResolveStereoPlayoutAvailability: Manual rendering mode does not support stereo.";
+    *available = false;
+    return 0;
+  }
+
+#if defined(WEBRTC_IOS)
+  AVAudioSession* session = [AVAudioSession sharedInstance];
+  NSString* mode = session.mode;
+  AVAudioSessionRouteDescription* current_route = session.currentRoute;
+  NSString* route_description = current_route.description;
+
+  LOGI() << "ResolveStereoPlayoutAvailability {"
+         << "currentRoute: "<< (route_description ? route_description.UTF8String : "unknown")
+         << "mode: " << (mode ? mode.UTF8String : "unknown")
+         << " }";
+
+  static NSSet<NSString*>* const kMonoModes = [NSSet setWithArray:@[
+    AVAudioSessionModeVoiceChat,
+    AVAudioSessionModeVideoChat,
+    AVAudioSessionModeGameChat
+  ]];
+
+  if ([kMonoModes containsObject:mode]) {
+    LOGI() << "ResolveStereoPlayoutAvailability: 0 (mode is mono)";
+    *available = false;
+    return 0;
+  }
+
+  NSInteger channel_count = session.outputNumberOfChannels;
+  if (channel_count < 2) {
+    AVAudioSessionRouteDescription* route = session.currentRoute;
+    for (AVAudioSessionPortDescription* port in route.outputs) {
+      channel_count = std::max(channel_count, (NSInteger)port.channels.count);
+    }
+  }
+
+  if (channel_count < 2) {
+    LOGI() << "ResolveStereoPlayoutAvailability: 0 (channel count is mono)";
+    *available = false;
+    return 0;
+  }
+
+  LOGI() << "ResolveStereoPlayoutAvailability {"
+         << "currentRoute: "<< (route_description ? route_description.UTF8String : "unknown")
+         << "mode: " << (mode ? mode.UTF8String : "unknown")
+         << "channelCount: " << channel_count
+         << " }";
+
+  *available = true;
+#else
+  *available = true;
+#endif
 
   return 0;
 }

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2542,12 +2542,23 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
 
 void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
                                                      EngineStateUpdate state) {
-  RTC_DCHECK_RUN_ON(thread_);
+  RTC_DCHECK(engine_device_ != nil);
+  RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
 
   const bool input_active =
       state.prev.IsInputEnabled() || state.next.IsInputEnabled();
   if (!input_active || input_node == nil) {
     LOGW() << "ConfigureVoiceProcessingNode called with input disabled; skipping";
+    return;
+  }
+
+  if ([input_node respondsToSelector:NSSelectorFromString(@"voiceProcessingEnabled")] == NO) {
+    LOGW() << "AVAudioInputNode does not support voice processing; skipping configuration";
+    return;
+  }
+
+  if ([input_node respondsToSelector:NSSelectorFromString(@"voiceProcessingInputMuted")] == NO) {
+    LOGW() << "AVAudioInputNode does not support voice processing; skipping configuration";
     return;
   }
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -336,6 +336,20 @@ int32_t AudioEngineDevice::Terminate() {
   return 0;
 }
 
+int32_t AudioEngineDevice::Reset() {
+  LOGI() << "Reset";
+  RTC_DCHECK_RUN_ON(thread_);
+  if (!initialized_) {
+    return 0;
+  }
+
+  StopPlayout();
+  StopRecording();
+  ResetEngineState();
+
+  return 0;
+}
+
 // ----------------------------------------------------------------------------------------------------
 // Playout
 
@@ -1435,6 +1449,29 @@ bool AudioEngineDevice::IsMicrophonePermissionGranted() {
   return status == AVAuthorizationStatusAuthorized;
 }
 
+void AudioEngineDevice::ResetEngineState() {
+  LOGI() << "ResetEngineState";
+  RTC_DCHECK_RUN_ON(thread_);
+
+  int32_t result =
+      ModifyEngineState([](EngineState /*state*/) -> EngineState {
+        EngineState reset;
+        return reset;
+      });
+  if (result != 0) {
+    LOGE() << "ResetEngineState: failed to reset engine state, error: " << result;
+    return;
+  }
+
+  // Clear the stereo override bookkeeping; the current engine_state_ has already been
+  // updated by ModifyEngineState so we can seed our caches from it.
+  stereo_voice_processing_override_active_ = false;
+  stereo_saved_voice_processing_enabled_ = engine_state_.voice_processing_enabled;
+  stereo_saved_voice_processing_bypassed_ = engine_state_.voice_processing_bypassed;
+  stereo_saved_voice_processing_agc_enabled_ = engine_state_.voice_processing_agc_enabled;
+  manual_restore_voice_processing_on_mono_ = false;
+}
+
 int32_t AudioEngineDevice::ModifyEngineState(
     std::function<EngineState(EngineState)> state_transform) {
   RTC_DCHECK_RUN_ON(thread_);
@@ -1453,23 +1490,6 @@ int32_t AudioEngineDevice::ModifyEngineState(
     LOGE() << "ModifyEngineState: Failed to resolve stereo playout availability";
     state.next.stereo_playout_available = false;
   }
-
-  // --------------------------------------------------------------------------------------------
-  // Step: Configure Stereo Playout
-  //
-
-  if (state.next.IsOutputEnabled() &&
-        (!state.prev.IsOutputEnabled() || state.IsEngineRecreateRequired())) {
-    RTC_DCHECK(!engine_device_.running);
-    
-    const uint32_t desired_channels = state.next.DesiredOutputChannels();
-    const bool applied_stereo = desired_channels >= 2;
-
-    state.next.stereo_playout_enabled = applied_stereo;
-    LOGI() << "Stereo playout optimistic update: " << applied_stereo;
-  }
-
-  UpdateVoiceProcessingForStereoState(state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Debugging Output
@@ -1497,7 +1517,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
          << ", DidEnableDeviceRenderingMode: " << state.DidEnableDeviceRenderingMode()
          << ", DidUpdateDesiredOutputChannels: " << state.DidUpdateDesiredOutputChannels()
          << " }";
-  DebugEngineState("ModifyEngineState: Old State", state.prev);
+  DebugEngineState("ModifyEngineState: Previous State", state.prev);
   DebugEngineState("ModifyEngineState: Next State", state.next);
 
   // No changes, return immediately.
@@ -2007,81 +2027,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
   }
 
   // --------------------------------------------------------------------------------------------
-  // Step: Configure Voice-Processing I/O
-  //
-  if (state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-#if TARGET_OS_SIMULATOR
-    LOGI() << "setVoiceProcessingEnabled (input): "
-           << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
-#else
-    LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
-                                                                                           : "NO";
-    NSError* error = nil;
-    BOOL set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                          error:&error];
-    if (!set_vp_result) {
-      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
-      RTC_DCHECK(set_vp_result);
-    }
-    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
-#endif
-
-    if (inputNode().voiceProcessingEnabled) {
-      // Always unmute vp if restart mute mode.
-      if (state.next.mute_mode == MuteMode::RestartEngine &&
-          inputNode().voiceProcessingInputMuted) {
-        LOGI() << "Update mute (voice processing) unmuting vp for restart engine mode";
-        inputNode().voiceProcessingInputMuted = false;
-      }
-
-      if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
-        // Muted talker detection.
-        AVAudioSession* session = [AVAudioSession sharedInstance];
-        NSString* mode = session.mode;
-        static NSSet<NSString*>* const kMonoModes = [NSSet setWithArray:@[
-          AVAudioSessionModeVoiceChat,
-          AVAudioSessionModeVideoChat
-        ]];
-
-        if ([kMonoModes containsObject:mode]) {
-          LOGI() << "Setting muted speech activity listener for mode: " << mode.UTF8String;
-
-          auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
-            LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
-            RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
-                      event == AVAudioVoiceProcessingSpeechActivityEnded);
-            AudioDeviceModule::SpeechActivityEvent rtc_event =
-                (event == AVAudioVoiceProcessingSpeechActivityStarted
-                    ? AudioDeviceModule::SpeechActivityEvent::kStarted
-                    : AudioDeviceModule::SpeechActivityEvent::kEnded);
-
-            thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
-              RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
-              if (this->observer_ != nullptr) {
-                this->observer_->OnSpeechActivityEvent(rtc_event);
-              }
-            }));
-          };
-
-          BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:listener_block];
-          if (set_listener_result) {
-            LOGI() << "setMutedSpeechActivityEventListener: listener installed successfully";
-          } else {
-            LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is videoChat or voiceChat.";
-          }
-        } else {
-          BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:nil];
-          if (set_listener_result) {
-            LOGI() << "setMutedSpeechActivityEventListener: listener uninstalled successfully";
-          } 
-        }
-      }
-    }
-  }
-
-
-  // --------------------------------------------------------------------------------------------
   // Step: Enable output
   //
   if (state.next.IsOutputEnabled() &&
@@ -2096,6 +2041,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     const uint32_t hardware_channels =
         static_cast<uint32_t>(std::max<NSInteger>(1, output_node_format.channelCount));
     const uint32_t applied_channels = std::min(desired_channels, hardware_channels);
+    const bool applied_stereo = desired_channels >= 2;
+    state.next.stereo_playout_enabled = applied_stereo;
+    LOGI() << "Stereo playout optimistic update: " << applied_stereo;
 
     LOGI() << "Output format sampleRate: " << output_node_format.sampleRate
            << " channels: " << output_node_format.channelCount
@@ -2183,6 +2131,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     AVAudioFormat* mixer_format = [engine_device_.mainMixerNode outputFormatForBus:0];
     if (mixer_format.channelCount < applied_channels) {
       LOGW() << "Mixer forced channel count to " << mixer_format.channelCount;
+      state.next.stereo_playout_enabled = mixer_format.channelCount >= 2;
     } else {
       LOGI() << "Mixer accepted channel count to " << mixer_format.channelCount;
     }
@@ -2217,6 +2166,12 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
       source_node_ = nil;
     }
   }
+
+  // --------------------------------------------------------------------------------------------
+  // Step: Configure Voice-Processing I/O
+  //
+  UpdateVoiceProcessingForStereoState(state);
+  ConfigureVoiceProcessingNode(inputNode(), state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Enable input
@@ -2657,26 +2612,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
 
 void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
                                                      EngineStateUpdate state) {
-  RTC_DCHECK(engine_device_ != nil);
-  RTC_DCHECK(state.prev.IsInputEnabled() || state.next.IsInputEnabled());
-
-  const bool input_active =
-      state.prev.IsInputEnabled() || state.next.IsInputEnabled();
-  if (!input_active || input_node == nil) {
-    LOGW() << "ConfigureVoiceProcessingNode called with input disabled; skipping";
-    return;
-  }
-
-  if ([input_node respondsToSelector:NSSelectorFromString(@"voiceProcessingEnabled")] == NO) {
-    LOGW() << "AVAudioInputNode does not support voice processing; skipping configuration";
-    return;
-  }
-
-  if ([input_node respondsToSelector:NSSelectorFromString(@"voiceProcessingInputMuted")] == NO) {
-    LOGW() << "AVAudioInputNode does not support voice processing; skipping configuration";
-    return;
-  }
-
   if (state.next.IsInputEnabled() && input_node.voiceProcessingEnabled != state.next.voice_processing_enabled) {
     #if TARGET_OS_SIMULATOR
         LOGI() << "setVoiceProcessingEnabled (input): "
@@ -2709,7 +2644,6 @@ void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_nod
 
 void AudioEngineDevice::ConfigureMutedSpeechActivityEventListener(AVAudioInputNode* input_node, 
                                                                   EngineStateUpdate state) {
-  RTC_DCHECK_RUN_ON(thread_);
   const bool input_active =
       state.prev.IsInputEnabled() || state.next.IsInputEnabled();
   if (!input_active || input_node == nil) {

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -683,6 +683,12 @@ int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& s
 
   *available = false;
 
+  if (state.input_running && !state.input_muted) {
+    LOGI() << "ResolveStereoPlayoutAvailability: Stereo support isn't available while input is running and not muted.";
+    *available = false;
+    return 0;
+  }
+
   if (state.render_mode == RenderMode::Manual) {
     LOGI() << "ResolveStereoPlayoutAvailability: Manual rendering mode does not support stereo.";
     *available = false;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -774,34 +774,68 @@ void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restor
 }
 
 void AudioEngineDevice::UpdateVoiceProcessingForStereoState(EngineStateUpdate& state) {
+  const bool didUpdateStereoPlayoutEnabled = 
+      state.prev.stereo_playout_enabled != state.next.stereo_playout_enabled;
   const bool enabling_stereo = !state.prev.stereo_playout_enabled && state.next.stereo_playout_enabled;
   const bool disabling_stereo = state.prev.stereo_playout_enabled && !state.next.stereo_playout_enabled;
 
-  if (enabling_stereo) {
+  LOGI() << "UpdateVoiceProcessingForStereoState: { "
+         << " didUpdateStereoPlayoutEnabled: " << didUpdateStereoPlayoutEnabled
+         << ", enabling_stereo: " << enabling_stereo
+         << ", disabling_stereo: " << disabling_stereo
+         << ", stereo_voice_processing_override_active_: " << stereo_voice_processing_override_active_
+         << ", manual_restore_voice_processing_on_mono_: " << manual_restore_voice_processing_on_mono_
+         << " }";
+
+  if (state.next.stereo_playout_enabled) {
     if (!stereo_voice_processing_override_active_) {
       stereo_voice_processing_override_active_ = true;
       stereo_saved_voice_processing_enabled_ = state.prev.voice_processing_enabled;
       stereo_saved_voice_processing_bypassed_ = state.prev.voice_processing_bypassed;
       stereo_saved_voice_processing_agc_enabled_ = state.prev.voice_processing_agc_enabled;
+      LOGI() << "Saving VP state for stereo override: { "
+              << " voice_processing_enabled: " << stereo_saved_voice_processing_enabled_
+              << ", voice_processing_bypassed: " << stereo_saved_voice_processing_bypassed_
+              << ", voice_processing_agc_enabled: " << stereo_saved_voice_processing_agc_enabled_
+              << " }";
     }
 
-    // Force VP/AGC into the disabled state required for stereo
-    state.next.voice_processing_enabled = false;
-    state.next.voice_processing_bypassed = true;
-    state.next.voice_processing_agc_enabled = false;
-    return;
-  }
-
-  if (disabling_stereo && stereo_voice_processing_override_active_) {
-    if (!manual_restore_voice_processing_on_mono_) {
+    if (state.next.voice_processing_enabled || state.next.voice_processing_agc_enabled) {
+      // Force VP/AGC into the disabled state required for stereo
+      state.next.voice_processing_enabled = false;
+      state.next.voice_processing_bypassed = true;
+      state.next.voice_processing_agc_enabled = false;
+      LOGI() << "Disabling VP/AGC for stereo playback";
+    }
+  } else {
+    if (stereo_voice_processing_override_active_) {
       state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
       state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
       state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
       stereo_voice_processing_override_active_ = false;
+      
+      LOGI() << "Restoring VP state from stereo override: { "
+              << " voice_processing_enabled: " << stereo_saved_voice_processing_enabled_
+              << ", voice_processing_bypassed: " << stereo_saved_voice_processing_bypassed_
+              << ", voice_processing_agc_enabled: " << stereo_saved_voice_processing_agc_enabled_
+              << " }";
+    } else {
+      if (!state.next.voice_processing_enabled) {
+        // We recover VP from the default state
+        EngineState initial_state;
+        state.next.voice_processing_enabled = initial_state.voice_processing_enabled;
+        state.next.voice_processing_bypassed = initial_state.voice_processing_bypassed;
+        state.next.voice_processing_agc_enabled = initial_state.voice_processing_agc_enabled;
+        LOGI() << "Restoring VP state from default: { "
+                << " voice_processing_enabled: " << state.next.voice_processing_enabled
+                << ", voice_processing_bypassed: " << state.next.voice_processing_bypassed
+                << ", voice_processing_agc_enabled: " << state.next.voice_processing_agc_enabled
+                << " }";
+      }
     }
-    // If manual_restore_voice_processing_on_mono_ is true, we leave the saved values
-    // untouched so the user can decide when to re-enable VP/AGC.
   }
+
+  DebugEngineState("UpdateVoiceProcessingForStereoState: Completed", state.next);
 }
 
 void AudioEngineDevice::RefreshStereoPlayoutState() {

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -20,7 +20,6 @@
 #include "audio_engine_device.h"
 
 #include <mach/mach_time.h>
-#include <algorithm>
 #include <cmath>
 
 #include "api/array_view.h"
@@ -87,10 +86,6 @@ AudioEngineDevice::AudioEngineDevice(bool voice_processing_bypassed)
 
   // Initial engine state
   engine_state_.voice_processing_bypassed = voice_processing_bypassed;
-  stereo_voice_processing_override_active_ = false;
-  stereo_saved_voice_processing_enabled_ = true;
-  stereo_saved_voice_processing_bypassed_ = false;
-  stereo_saved_voice_processing_agc_enabled_ = true;
 }
 
 AudioEngineDevice::~AudioEngineDevice() {
@@ -650,154 +645,30 @@ int32_t AudioEngineDevice::MicrophoneMute(bool* enabled) const {
 
 int32_t AudioEngineDevice::StereoPlayoutIsAvailable(bool* available) const {
   LOGI() << "StereoPlayoutIsAvailable";
-  RTC_DCHECK_RUN_ON(thread_);
-
   if (available == nullptr) {
     return -1;
   }
 
-  bool render_mode_allows_stereo = engine_state_.render_mode != RenderMode::Manual;
-  bool route_supports_stereo = RouteSupportsStereo();
-  bool available_value = render_mode_allows_stereo && route_supports_stereo;
-
-  *available = available_value;
-
-  if (observer_ != nullptr) {
-    observer_->OnStereoUpdatedPlayoutAvailable(available_value);
-  }
-
-  LOGI() << "StereoPlayoutIsAvailable: " << *available << " (render mode allows: "
-         << render_mode_allows_stereo
-         << ", route supports: " << route_supports_stereo << ")";
+  *available = false;
 
   return 0;
 }
 
-bool AudioEngineDevice::RouteSupportsStereo() const {
-  RTC_DCHECK_RUN_ON(thread_);
-
-#if defined(WEBRTC_IOS)
-  AVAudioSession* session = [AVAudioSession sharedInstance];
-  NSString* mode = session.mode;
-  AVAudioSessionRouteDescription* current_route = session.currentRoute;
-  NSString* route_description = current_route.description;
-
-  LOGI() << "RouteSupportsStereo: current_route ("
-         << (route_description ? route_description.UTF8String : "unknown") << ")";
-  LOGI() << "RouteSupportsStereo: mode active (" << [mode UTF8String] << ")";
-
-  static NSArray<NSString*>* const kMonoModes = @[
-    AVAudioSessionModeVoiceChat,
-    AVAudioSessionModeVideoChat,
-    AVAudioSessionModeGameChat
-  ];
-
-  for (NSString* mono_mode in kMonoModes) {
-    if ([mode isEqualToString:mono_mode]) {
-      LOGI() << "RouteSupportsStereo: Mono mode active (" << [mode UTF8String] << ")";
-      return false;
-    }
-  }
-
-  NSInteger channel_count = session.outputNumberOfChannels;
-  if (channel_count < 2) {
-    AVAudioSessionRouteDescription* route = session.currentRoute;
-    for (AVAudioSessionPortDescription* port in route.outputs) {
-      channel_count = std::max(channel_count, (NSInteger)port.channels.count);
-    }
-  }
-
-  LOGI() << "RouteSupportsStereo channel_count: " << channel_count;
-  return channel_count >= 2;
-#else
-  return true;
-#endif
-}
-
 int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
-  RTC_DCHECK_RUN_ON(thread_);
-  LOGI() << "SetStereoPlayout: " << enable;
+  LOGW() << "SetStereoPlayout: Not implemented, value:" << enable;
 
-  if (engine_state_.stereo_playout_enabled == enable) {
-    return 0;
-  }
-
-  if (engine_state_.render_mode == RenderMode::Manual &&
-      enable != engine_state_.stereo_playout_enabled) {
-    LOGE() << "SetStereoPlayout: Manual rendering mode currently supports mono only";
-    return kAudioEngineManualRenderingError;
-  }
-
-  if (enable) {
-    bool available = false;
-    if (StereoPlayoutIsAvailable(&available) != 0 || !available) {
-      LOGE() << "SetStereoPlayout: Current audio route does not support stereo";
-      return kAudioEngineDeviceFormatError;
-    }
-  }
-
-  const bool vp_enabled_before = engine_state_.voice_processing_enabled;
-  const bool vp_bypassed_before = engine_state_.voice_processing_bypassed;
-  const bool vp_agc_enabled_before = engine_state_.voice_processing_agc_enabled;
-  const bool apply_vp_override = enable && vp_enabled_before;
-
-  if (enable && apply_vp_override) {
-    LOGW() << "Stereo playout requested while voice processing enabled; disabling voice processing";
-  }
-
-  int32_t result = ModifyEngineState([this, enable, apply_vp_override](EngineState state) -> EngineState {
-    state.stereo_playout_enabled = enable;
-    if (enable) {
-      if (apply_vp_override) {
-        state.voice_processing_enabled = false;
-        state.voice_processing_bypassed = false;
-        state.voice_processing_agc_enabled = false;
-      }
-    } else {
-      if (stereo_voice_processing_override_active_) {
-        state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-        state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-        state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-      }
-    }
-    return state;
-  });
-
-  if (result != 0) {
-    return result;
-  }
-
-  if (enable) {
-    if (apply_vp_override) {
-      stereo_voice_processing_override_active_ = true;
-      stereo_saved_voice_processing_enabled_ = vp_enabled_before;
-      stereo_saved_voice_processing_bypassed_ = vp_bypassed_before;
-      stereo_saved_voice_processing_agc_enabled_ = vp_agc_enabled_before;
-    }
-  } else {
-    if (stereo_voice_processing_override_active_) {
-      stereo_voice_processing_override_active_ = false;
-    }
-  }
-
-  if (observer_ != nullptr) {
-    observer_->OnStereoUpdatedPlayoutEnabled(enable);
-  }
+  audio_device_buffer_->SetPlayoutChannels(1);
 
   return 0;
 }
 
 int32_t AudioEngineDevice::StereoPlayout(bool* enabled) const {
   LOGI() << "StereoPlayout";
-  RTC_DCHECK_RUN_ON(thread_);
-
   if (enabled == nullptr) {
     return -1;
   }
 
-  *enabled = engine_state_.stereo_playout_enabled;
-
-  LOGI() << "StereoPlayout: " << *enabled;
+  *enabled = false;
 
   return 0;
 }
@@ -1112,24 +983,8 @@ int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) { return -1; }
 // Misc
 
 #if defined(WEBRTC_IOS)
-int AudioEngineDevice::GetPlayoutAudioParameters(AudioParameters* params) const {
-  RTC_DCHECK_RUN_ON(thread_);
-  if (params == nullptr) {
-    return -1;
-  }
-
-  *params = playout_parameters_;
-  return params->is_valid() ? 0 : -1;
-}
-int AudioEngineDevice::GetRecordAudioParameters(AudioParameters* params) const {
-  RTC_DCHECK_RUN_ON(thread_);
-  if (params == nullptr) {
-    return -1;
-  }
-
-  *params = record_parameters_;
-  return params->is_valid() ? 0 : -1;
-}
+int AudioEngineDevice::GetPlayoutAudioParameters(AudioParameters* params) const { return -1; }
+int AudioEngineDevice::GetRecordAudioParameters(AudioParameters* params) const { return -1; }
 #endif
 
 int32_t AudioEngineDevice::PlayoutDelay(uint16_t* delayMS) const {
@@ -1256,17 +1111,6 @@ int32_t AudioEngineDevice::SetVoiceProcessingAGCEnabled(bool enable) {
   return result;
 }
 
-void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restore) {
-  RTC_DCHECK_RUN_ON(thread_);
-  LOGI() << "SetManualRestoreVoiceProcessingOnMono: " << manual_restore;
-  manual_restore_voice_processing_on_mono_ = manual_restore;
-}
-
-bool AudioEngineDevice::ManualRestoreVoiceProcessingOnMono() const {
-  RTC_DCHECK_RUN_ON(thread_);
-  return manual_restore_voice_processing_on_mono_;
-}
-
 int32_t AudioEngineDevice::ManualRenderingMode(bool* enabled) {
   LOGI() << "ManualRenderingMode";
   RTC_DCHECK_RUN_ON(thread_);
@@ -1286,9 +1130,6 @@ int32_t AudioEngineDevice::SetManualRenderingMode(bool enable) {
 
   int32_t result = ModifyEngineState([enable](EngineState state) -> EngineState {
     state.render_mode = enable ? RenderMode::Manual : RenderMode::Device;
-    if (enable) {
-      state.stereo_playout_enabled = false;
-    }
     return state;
   });
 
@@ -1425,24 +1266,6 @@ void AudioEngineDevice::ReconfigureEngine() {
 
     EngineState current_state = this->engine_state_;
 
-    if (current_state.stereo_playout_enabled) {
-      bool available = false;
-      if (this->StereoPlayoutIsAvailable(&available) == 0 && !available) {
-        LOGW() << "Route change removed stereo support, reverting to mono";
-        current_state.stereo_playout_enabled = false;
-        if (stereo_voice_processing_override_active_) {
-          if (manual_restore_voice_processing_on_mono_) {
-            LOGW() << "Skipping voice processing restore after route change (manual restore enabled)";
-          } else {
-            current_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-            current_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-            current_state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-          }
-          stereo_voice_processing_override_active_ = false;
-        }
-      }
-    }
-
     // Re-configure is only for device mode
     if (current_state.render_mode != RenderMode::Device) return;
 
@@ -1484,30 +1307,8 @@ int32_t AudioEngineDevice::ModifyEngineState(
   RTC_DCHECK_RUN_ON(thread_);
 
   EngineState old_state = engine_state_;
-  EngineStateUpdate state = {old_state, state_transform(old_state)};
-  EngineState& new_state = state.next;
-  bool route_forces_mono = false;
-  bool route_restore_voice_processing = false;
-
-  if (state.next.stereo_playout_enabled && !RouteSupportsStereo()) {
-    LOGW() << "Route does not support stereo, forcing mono";
-    state.next.stereo_playout_enabled = false;
-    route_forces_mono = true;
-    if (stereo_voice_processing_override_active_) {
-      if (manual_restore_voice_processing_on_mono_) {
-        LOGW() << "Skipping voice processing restore after stereo fallback (manual restore enabled)";
-        stereo_voice_processing_override_active_ = false;
-      } else {
-        route_restore_voice_processing = true;
-        state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-        state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-        state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-      }
-    }
-  }
-
-  bool stereo_reset = route_forces_mono;
-  bool restore_voice_processing = route_restore_voice_processing;
+  EngineState new_state = state_transform(old_state);
+  EngineStateUpdate state = {old_state, new_state};
 
   // No changes, return immediately.
   if (state.HasNoChanges()) {
@@ -1526,12 +1327,6 @@ int32_t AudioEngineDevice::ModifyEngineState(
     return -1;
   }
 
-  if (new_state.stereo_playout_enabled && new_state.voice_processing_enabled &&
-      !new_state.voice_processing_bypassed) {
-    LOGE() << "ModifyEngineState: Stereo playout requires voice processing to be disabled or bypassed";
-    return kAudioEngineVoiceProcessingError;
-  }
-
   int32_t shutdown_result = 0;
   int32_t startup_result = 0;
 
@@ -1539,10 +1334,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
   if (state.DidEnableManualRenderingMode()) {
     EngineStateUpdate shutdown_state = state;                  // Copy current state
     shutdown_state.next = {};                                  // Reset next state to default
-    stereo_reset = false;
-    restore_voice_processing = false;
-    shutdown_result = ApplyDeviceEngineState(shutdown_state, &stereo_reset,
-                                             &restore_voice_processing);  // Shutdown device rendering
+    shutdown_result = ApplyDeviceEngineState(shutdown_state);  // Shutdown device rendering
     if (shutdown_result != 0) {
       LOGE() << "ModifyEngineState: Failed to shutdown device rendering, error: "
              << shutdown_result;
@@ -1563,17 +1355,12 @@ int32_t AudioEngineDevice::ModifyEngineState(
     }
     EngineStateUpdate startup_state = state;                 // Copy current state
     shutdown_state.prev = {};                                //
-    stereo_reset = false;
-    restore_voice_processing = false;
-    startup_result = ApplyDeviceEngineState(startup_state, &stereo_reset,
-                                            &restore_voice_processing);  // Start device mode
+    startup_result = ApplyDeviceEngineState(startup_state);  // Start device mode
     if (startup_result != 0) {
       LOGE() << "ModifyEngineState: Failed to start device mode, error: " << startup_result;
     }
   } else if (new_state.render_mode == RenderMode::Device) {
-    stereo_reset = false;
-    restore_voice_processing = false;
-    shutdown_result = ApplyDeviceEngineState(state, &stereo_reset, &restore_voice_processing);
+    shutdown_result = ApplyDeviceEngineState(state);
     if (shutdown_result != 0) {
       LOGE() << "ModifyEngineState: Failed to update state in device mode, error: "
              << shutdown_result;
@@ -1590,19 +1377,6 @@ int32_t AudioEngineDevice::ModifyEngineState(
 
   // Additional checks for buffer state.
   if (return_result == 0) {
-    if (stereo_reset && new_state.stereo_playout_enabled) {
-      LOGW() << "Stereo playout disabled due to output route constraints";
-      new_state.stereo_playout_enabled = false;
-    }
-
-    if (restore_voice_processing && stereo_voice_processing_override_active_) {
-      LOGW() << "Restoring voice processing after stereo fallback";
-      new_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-      new_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-      new_state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-      stereo_voice_processing_override_active_ = false;
-    }
-
     // Buffer should be playing if output is running.
     if (new_state.IsOutputEnabled()) {
       RTC_DCHECK(audio_device_buffer_->IsPlaying());
@@ -1734,7 +1508,6 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
 
     audio_device_buffer_->SetPlayoutSampleRate(manual_render_rtc_format_.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(manual_render_rtc_format_.channelCount);
-    playout_parameters_.reset(manual_render_rtc_format_.sampleRate, manual_render_rtc_format_.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -1749,7 +1522,6 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
 
     audio_device_buffer_->SetRecordingSampleRate(manual_render_rtc_format_.sampleRate);
     audio_device_buffer_->SetRecordingChannels(manual_render_rtc_format_.channelCount);
-    record_parameters_.reset(manual_render_rtc_format_.sampleRate, manual_render_rtc_format_.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -1861,18 +1633,9 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
   return 0;
 }
 
-int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
-                                                  bool* stereo_playout_reset,
-                                                  bool* restore_voice_processing) {
+int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_manual_input_ == nullptr);
-
-  if (stereo_playout_reset) {
-    *stereo_playout_reset = false;
-  }
-  if (restore_voice_processing) {
-    *restore_voice_processing = false;
-  }
 
   std::vector<std::function<void()>> rollback_actions;
 
@@ -2020,13 +1783,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
     BOOL set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
                                                           error:&error];
     if (!set_vp_result) {
-      LOGE() << "setVoiceProcessingEnabled (input) failed: "
-             << (error ? error.localizedDescription.UTF8String : "Unknown error");
-      state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
-      state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
+      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
+      RTC_DCHECK(set_vp_result);
     }
-    LOGI() << "setVoiceProcessingEnabled (input) result: "
-           << (set_vp_result ? "YES" : "NO");
+    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
 #endif
 
     if (inputNode().voiceProcessingEnabled) {
@@ -2093,108 +1853,22 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
       return rollback(kAudioEnginePlayoutDeviceNotAvailableError);
     }
 
-    AVAudioChannelCount requested_channels =
-        static_cast<AVAudioChannelCount>(state.next.DesiredOutputChannels());
-    AVAudioChannelCount hardware_channels = output_node_format.channelCount;
-
-    if (requested_channels == 0) {
-      requested_channels = 1;
-    }
-
-    if (requested_channels > hardware_channels) {
-      LOGW() << "Requested playout channels " << requested_channels
-             << " exceeds hardware capability " << hardware_channels << ", falling back";
-      requested_channels = std::max<AVAudioChannelCount>(1, hardware_channels);
-      if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
-        *stereo_playout_reset = true;
-      }
-        if (restore_voice_processing && state.next.stereo_playout_enabled &&
-            stereo_voice_processing_override_active_) {
-          *restore_voice_processing = true;
-          state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-          state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-          state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-#if !TARGET_OS_SIMULATOR
-          if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-            NSError* vp_error = nil;
-            BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                          error:&vp_error];
-          if (!set_vp) {
-            LOGE() << "Failed to restore voice processing: "
-                   << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
-            state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
-            state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
-            if (restore_voice_processing) {
-              *restore_voice_processing = false;
-            }
-            stereo_voice_processing_override_active_ = false;
-          } else if (state.next.voice_processing_enabled &&
-                     inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
-            inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
-          }
-        } else if (state.next.voice_processing_enabled &&
-                   inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
-          inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
-        }
-#endif
-      }
-    } else if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
-      // Handle cases where desired stereo was set but route currently only reports mono channels.
-      *stereo_playout_reset = true;
-        if (restore_voice_processing && stereo_voice_processing_override_active_) {
-          *restore_voice_processing = true;
-          state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-          state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-          state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-#if !TARGET_OS_SIMULATOR
-          if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-            NSError* vp_error = nil;
-            BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                          error:&vp_error];
-          if (!set_vp) {
-            LOGE() << "Failed to restore voice processing: "
-                   << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
-            state.next.voice_processing_enabled = inputNode().voiceProcessingEnabled;
-            state.next.voice_processing_bypassed = inputNode().voiceProcessingBypassed;
-            if (restore_voice_processing) {
-              *restore_voice_processing = false;
-            }
-            stereo_voice_processing_override_active_ = false;
-          } else if (state.next.voice_processing_enabled &&
-                     inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
-            inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
-          }
-        } else if (state.next.voice_processing_enabled &&
-                   inputNode().voiceProcessingBypassed != state.next.voice_processing_bypassed) {
-          inputNode().voiceProcessingBypassed = state.next.voice_processing_bypassed;
-        }
-#endif
-      }
-    }
-
     AVAudioFormat* engine_output_format = [[AVAudioFormat alloc]
         initWithCommonFormat:output_node_format.commonFormat  // Usually float32
                   sampleRate:output_node_format.sampleRate
-                    channels:requested_channels
+                    channels:1
                  interleaved:output_node_format.interleaved];
-    LOGI() << "Engine output format sampleRate=" << engine_output_format.sampleRate
-           << ", channels=" << engine_output_format.channelCount
-           << ", interleaved=" << (engine_output_format.interleaved ? "YES" : "NO");
 
     audio_device_buffer_->SetPlayoutSampleRate(engine_output_format.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(engine_output_format.channelCount);
-    playout_parameters_.reset(engine_output_format.sampleRate, engine_output_format.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
     AVAudioFormat* rtc_output_format =
         [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
                                          sampleRate:engine_output_format.sampleRate
-                                           channels:requested_channels
+                                           channels:1
                                         interleaved:YES];
-    LOGI() << "RTC output format sampleRate=" << rtc_output_format.sampleRate
-           << ", channels=" << rtc_output_format.channelCount
-           << ", interleaved=" << (rtc_output_format.interleaved ? "YES" : "NO");
 
     AVAudioSourceNodeRenderBlock source_block =
         ^OSStatus(BOOL* isSilence, const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount,
@@ -2204,9 +1878,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
           int16_t* dest_buffer = (int16_t*)outputData->mBuffers[0].mData;
 
           fine_audio_buffer_->GetPlayoutData(
-              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer),
-                                         static_cast<size_t>(frameCount) *
-                                             rtc_output_format.channelCount),
+              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer), frameCount),
               kFixedPlayoutDelayEstimate);
 
           return noErr;
@@ -2311,7 +1983,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
 
     audio_device_buffer_->SetRecordingSampleRate(rtc_input_format.sampleRate);
     audio_device_buffer_->SetRecordingChannels(rtc_input_format.channelCount);
-    record_parameters_.reset(rtc_input_format.sampleRate, rtc_input_format.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -2648,14 +2319,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
       }
 
       if (start_result) {
+        RTC_DCHECK(configuration_observer_ == nullptr);
+        // Add observer for configuration changes
         NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-        if (configuration_observer_ != nullptr) {
-          [center removeObserver:(__bridge_transfer id)configuration_observer_
-                            name:AVAudioEngineConfigurationChangeNotification
-                          object:nil];
-          configuration_observer_ = nullptr;
-        }
-
         configuration_observer_ = (__bridge_retained void*)[center
             addObserverForName:AVAudioEngineConfigurationChangeNotification
                         object:engine_device_
@@ -2705,8 +2371,7 @@ void AudioEngineDevice::StartRenderLoop() {
 
   const double sample_rate = manual_render_rtc_format_.sampleRate;
   const size_t frames_per_buffer = static_cast<size_t>(sample_rate / 100);  // 10ms chunks
-  const size_t channel_count = static_cast<size_t>(manual_render_rtc_format_.channelCount);
-  const size_t buffer_size = frames_per_buffer * channel_count * kAudioSampleSize;
+  const size_t buffer_size = frames_per_buffer * kAudioSampleSize;
   const int chunk_ms =
       static_cast<int>(std::round(1000.0 * static_cast<double>(frames_per_buffer) / sample_rate));
   int64_t next_wakeup_ms = rtc::TimeMillis();
@@ -2723,8 +2388,7 @@ void AudioEngineDevice::StartRenderLoop() {
 
     // Call GetPlayoutData to pull frames into rtc audio stack even though we won't use it here.
     fine_audio_buffer_->GetPlayoutData(
-        webrtc::ArrayView<int16_t>(read_rtc_buffer, frames_per_buffer * channel_count),
-        kFixedPlayoutDelayEstimate);
+        webrtc::ArrayView<int16_t>(read_rtc_buffer, frames_per_buffer), kFixedPlayoutDelayEstimate);
 
     // Render (Input)
     RTC_DCHECK(render_buffer_ != nullptr);
@@ -2743,7 +2407,7 @@ void AudioEngineDevice::StartRenderLoop() {
       const int64_t capture_time_ns = capture_time * machTickUnitsToNanoseconds_;
 
       fine_audio_buffer_->DeliverRecordedData(
-          webrtc::ArrayView<const int16_t>(rtc_buffer, frames_per_buffer * channel_count),
+          webrtc::ArrayView<const int16_t>(rtc_buffer, frames_per_buffer),
           kFixedRecordDelayEstimate, capture_time_ns);
     } else {
       LOGW() << "Render error: " << err << " frames: " << frames_per_buffer;

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -683,12 +683,6 @@ int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& s
 
   *available = false;
 
-  if (state.input_running && !state.input_muted) {
-    LOGI() << "ResolveStereoPlayoutAvailability: Stereo support isn't available while input is running and not muted.";
-    *available = false;
-    return 0;
-  }
-
   if (state.render_mode == RenderMode::Manual) {
     LOGI() << "ResolveStereoPlayoutAvailability: Manual rendering mode does not support stereo.";
     *available = false;
@@ -763,31 +757,30 @@ void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restor
   ModifyEngineState([](EngineState state) { return state; });
 }
 
-void AudioEngineDevice::UpdateVoiceProcessingForStereoState(const EngineState& prev,
-                                                            EngineState& next) {
-  const bool enabling_stereo = !prev.stereo_playout_enabled && next.stereo_playout_enabled;
-  const bool disabling_stereo = prev.stereo_playout_enabled && !next.stereo_playout_enabled;
+void AudioEngineDevice::UpdateVoiceProcessingForStereoState(EngineStateUpdate& state) {
+  const bool enabling_stereo = !state.prev.stereo_playout_enabled && state.next.stereo_playout_enabled;
+  const bool disabling_stereo = state.prev.stereo_playout_enabled && !state.next.stereo_playout_enabled;
 
   if (enabling_stereo) {
     if (!stereo_voice_processing_override_active_) {
       stereo_voice_processing_override_active_ = true;
-      stereo_saved_voice_processing_enabled_ = prev.voice_processing_enabled;
-      stereo_saved_voice_processing_bypassed_ = prev.voice_processing_bypassed;
-      stereo_saved_voice_processing_agc_enabled_ = prev.voice_processing_agc_enabled;
+      stereo_saved_voice_processing_enabled_ = state.prev.voice_processing_enabled;
+      stereo_saved_voice_processing_bypassed_ = state.prev.voice_processing_bypassed;
+      stereo_saved_voice_processing_agc_enabled_ = state.prev.voice_processing_agc_enabled;
     }
 
     // Force VP/AGC into the disabled state required for stereo
-    next.voice_processing_enabled = false;
-    next.voice_processing_bypassed = true;
-    next.voice_processing_agc_enabled = false;
+    state.next.voice_processing_enabled = false;
+    state.next.voice_processing_bypassed = true;
+    state.next.voice_processing_agc_enabled = false;
     return;
   }
 
   if (disabling_stereo && stereo_voice_processing_override_active_) {
     if (!manual_restore_voice_processing_on_mono_) {
-      next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-      next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-      next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
+      state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+      state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+      state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
       stereo_voice_processing_override_active_ = false;
     }
     // If manual_restore_voice_processing_on_mono_ is true, we leave the saved values
@@ -1443,7 +1436,7 @@ bool AudioEngineDevice::IsMicrophonePermissionGranted() {
 int32_t AudioEngineDevice::ModifyEngineState(
     std::function<EngineState(EngineState)> state_transform) {
   RTC_DCHECK_RUN_ON(thread_);
-
+  
   EngineState old_state = engine_state_;
   EngineState new_state = state_transform(old_state);
   EngineStateUpdate state = {old_state, new_state};
@@ -1459,17 +1452,18 @@ int32_t AudioEngineDevice::ModifyEngineState(
 
   // No changes, return immediately.
   if (state.HasNoChanges()) {
+    LOGI() << "ModifyEngineState: No changes";
     return 0;
   }
 
   // Check input should be enabled if running.
-  if (new_state.input_running && !new_state.input_enabled) {
+  if (state.next.input_running && !state.next.input_enabled) {
     LOGE() << "ModifyEngineState: Input must be enabled if running";
     return -1;
   }
 
   // Check output should be enabled if running.
-  if (new_state.output_running && !new_state.output_enabled) {
+  if (state.next.output_running && !state.next.output_enabled) {
     LOGE() << "ModifyEngineState: Output must be enabled if running";
     return -1;
   }
@@ -1506,13 +1500,13 @@ int32_t AudioEngineDevice::ModifyEngineState(
     if (startup_result != 0) {
       LOGE() << "ModifyEngineState: Failed to start device mode, error: " << startup_result;
     }
-  } else if (new_state.render_mode == RenderMode::Device) {
+  } else if (state.next.render_mode == RenderMode::Device) {
     shutdown_result = ApplyDeviceEngineState(state);
     if (shutdown_result != 0) {
       LOGE() << "ModifyEngineState: Failed to update state in device mode, error: "
              << shutdown_result;
     }
-  } else if (new_state.render_mode == RenderMode::Manual) {
+  } else if (state.next.render_mode == RenderMode::Manual) {
     startup_result = ApplyManualEngineState(state);
     if (startup_result != 0) {
       LOGE() << "ModifyEngineState: Failed to update state in manual mode, error: "
@@ -1525,7 +1519,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
   // Additional checks for buffer state.
   if (return_result == 0) {
     // Buffer should be playing if output is running.
-    if (new_state.IsOutputEnabled()) {
+    if (state.next.IsOutputEnabled()) {
       RTC_DCHECK(audio_device_buffer_->IsPlaying());
       if (!audio_device_buffer_->IsPlaying()) {
         LOGE() << "ModifyEngineState: Buffer should be playing when output is enabled";
@@ -1538,7 +1532,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
     }
 
     // Buffer should be recording if input is running.
-    if (new_state.IsInputEnabled()) {
+    if (state.next.IsInputEnabled()) {
       RTC_DCHECK(audio_device_buffer_->IsRecording());
       if (!audio_device_buffer_->IsRecording()) {
         LOGE() << "ModifyEngineState: Buffer should be recording when input is enabled";
@@ -1549,28 +1543,40 @@ int32_t AudioEngineDevice::ModifyEngineState(
         LOGE() << "ModifyEngineState: Buffer should not be recording when input is disabled";
       }
     }
+
+    // Notify observer of processing state changes if any
+    NotifyProcessingStateObserver(state);
     
-    AudioProcessingState proc_state;
-    proc_state.voice_processing_enabled = new_state.voice_processing_enabled;
-    proc_state.voice_processing_bypassed = new_state.voice_processing_bypassed;
-    proc_state.voice_processing_agc_enabled = new_state.voice_processing_agc_enabled;
-    proc_state.stereo_playout_enabled = new_state.stereo_playout_enabled;
-
-    if (observer_ && (state.prev.voice_processing_enabled != new_state.voice_processing_enabled ||
-                      state.prev.voice_processing_bypassed != new_state.voice_processing_bypassed ||
-                      state.prev.voice_processing_agc_enabled != new_state.voice_processing_agc_enabled ||
-                      state.prev.stereo_playout_enabled != new_state.stereo_playout_enabled)) {
-      observer_->OnAudioProcessingStateChanged(proc_state);
-    }
-
     // Update engine state if no error
-    engine_state_ = new_state;
+    engine_state_ = state.next;
+    LOGI() << "ModifyEngineState: "
+           << (state.IsEngineRecreateRequired() ? "Recreated" : state.IsEngineRestartRequired() ? "Restarted" : "Updated");
+    DebugEngineState(state.next);
   }
 
   return return_result;
 }
 
-int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
+void AudioEngineDevice::NotifyProcessingStateObserver(EngineStateUpdate state) {
+  RTC_DCHECK_RUN_ON(thread_);
+
+  AudioProcessingState proc_state;
+  proc_state.voice_processing_enabled = state.next.voice_processing_enabled;
+  proc_state.voice_processing_bypassed = state.next.voice_processing_bypassed;
+  proc_state.voice_processing_agc_enabled = state.next.voice_processing_agc_enabled;
+  proc_state.stereo_playout_enabled = state.next.stereo_playout_enabled;
+
+  bool processing_state_updated = state.prev.voice_processing_enabled !=  state.next.voice_processing_enabled ||
+                    state.prev.voice_processing_bypassed != state.next.voice_processing_bypassed ||
+                    state.prev.voice_processing_agc_enabled != state.next.voice_processing_agc_enabled ||
+                    state.prev.stereo_playout_enabled != state.next.stereo_playout_enabled;
+
+  if (observer_ && processing_state_updated) {
+    observer_->OnAudioProcessingStateChanged(proc_state);
+  }
+}
+
+int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate& state) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_device_ == nullptr);
 
@@ -1683,7 +1689,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
     audio_device_buffer_->SetPlayoutChannels(manual_render_rtc_format_.channelCount);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
-    UpdateVoiceProcessingForStereoState(state.prev, state.next);
+    UpdateVoiceProcessingForStereoState(state);
     ConfigureVoiceProcessingNode(engine_manual_input_.inputNode, state);
 
   } else if (state.prev.IsOutputEnabled() && !state.next.IsOutputEnabled()) {
@@ -1808,7 +1814,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
   return 0;
 }
 
-int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
+int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
   RTC_DCHECK_RUN_ON(thread_);
   RTC_DCHECK(engine_manual_input_ == nullptr);
 
@@ -2054,9 +2060,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     } else {
       LOGI() << "Mixer accepted channel count to " << mixer_format.channelCount;
     }
-    
-    LOGI() << "Updating VoiceProcessing state from the updated output configuration...";
-    UpdateVoiceProcessingForStereoState(state.prev, state.next);
+           
+    UpdateVoiceProcessingForStereoState(state);
 
     if (this->observer_ != nullptr) {
       NSDictionary* context = @{};
@@ -2297,7 +2302,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   if (state.next.mute_mode == MuteMode::VoiceProcessing && state.next.IsInputEnabled() &&
       inputNode().voiceProcessingEnabled &&
       inputNode().voiceProcessingInputMuted != state.next.input_muted) {
-    LOGI() << "Update mute (voice processing) runtime update" << state.next.input_muted;
+    LOGI() << "Update mute (voice processing) runtime update: " << state.next.input_muted;
     inputNode().voiceProcessingInputMuted = state.next.input_muted;
   }
 
@@ -2309,7 +2314,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     // Only update if the volume has changed.
     float mixer_volume = state.next.input_muted ? 0.0f : 1.0f;
     if (input_mixer_node_.outputVolume != mixer_volume) {
-      LOGI() << "Update mute (input mixer) runtime update" << state.next.input_muted;
+      LOGI() << "Update mute (input mixer) runtime update: " << state.next.input_muted;
       input_mixer_node_.outputVolume = mixer_volume;
     }
   }
@@ -2532,26 +2537,32 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 // Private - EngineState
 
 void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
-                                                     const EngineStateUpdate& state) {
+                                                     EngineStateUpdate state) {
   RTC_DCHECK_RUN_ON(thread_);
 
-  if (state.next.IsInputEnabled() &&
-      input_node.voiceProcessingEnabled != state.next.voice_processing_enabled) {
-#if TARGET_OS_SIMULATOR
-    LOGI() << "setVoiceProcessingEnabled (input): "
-           << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
-#else
-    LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
-                                                                                           : "NO";
-    NSError* error = nil;
-    BOOL set_vp_result = [input_node setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                          error:&error];
-    if (!set_vp_result) {
-      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
-      RTC_DCHECK(set_vp_result);
-    }
-    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
-#endif
+  const bool input_active =
+      state.prev.IsInputEnabled() || state.next.IsInputEnabled();
+  if (!input_active || input_node == nil) {
+    LOGW() << "ConfigureVoiceProcessingNode called with input disabled; skipping";
+    return;
+  }
+
+  if (state.next.IsInputEnabled() && input_node.voiceProcessingEnabled != state.next.voice_processing_enabled) {
+    #if TARGET_OS_SIMULATOR
+        LOGI() << "setVoiceProcessingEnabled (input): "
+              << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
+    #else
+        LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
+                                                                                              : "NO";
+        NSError* error = nil;
+        BOOL set_vp_result = [input_node setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                              error:&error];
+        if (!set_vp_result) {
+          NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
+          RTC_DCHECK(set_vp_result);
+        }
+        LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
+    #endif
 
     if (input_node.voiceProcessingEnabled) {
       // Always unmute vp if restart mute mode.
@@ -2561,33 +2572,61 @@ void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_nod
         input_node.voiceProcessingInputMuted = false;
       }
 
-      // Muted talker detection.
-      if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
-        auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
-          LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
-          RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
-                     event == AVAudioVoiceProcessingSpeechActivityEnded);
-          AudioDeviceModule::SpeechActivityEvent rtc_event =
-              (event == AVAudioVoiceProcessingSpeechActivityStarted
-                   ? AudioDeviceModule::SpeechActivityEvent::kStarted
-                   : AudioDeviceModule::SpeechActivityEvent::kEnded);
+      ConfigureMutedSpeechActivityEventListener(input_node, state);
+    }
+  } 
+}
 
-          thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
-            RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
-            if (this->observer_ != nullptr) {
-              this->observer_->OnSpeechActivityEvent(rtc_event);
-            }
-          }));
-        };
+void AudioEngineDevice::ConfigureMutedSpeechActivityEventListener(AVAudioInputNode* input_node, 
+                                                                  EngineStateUpdate state) {
+  RTC_DCHECK_RUN_ON(thread_);
+  const bool input_active =
+      state.prev.IsInputEnabled() || state.next.IsInputEnabled();
+  if (!input_active || input_node == nil) {
+    LOGW() << "ConfigureMutedSpeechActivityEventListener called with input disabled; skipping";
+    return;
+  }
 
-        BOOL set_listener_result = [input_node setMutedSpeechActivityEventListener:listener_block];
-        if (set_listener_result) {
-          LOGI() << "setMutedSpeechActivityEventListener success";
-        } else {
-          LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is "
-                    "videoChat or voiceChat.";
-        }
+  if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
+    // Muted talker detection.
+    AVAudioSession* session = [AVAudioSession sharedInstance];
+    NSString* mode = session.mode;
+    static NSSet<NSString*>* const kMonoModes = [NSSet setWithArray:@[
+      AVAudioSessionModeVoiceChat,
+      AVAudioSessionModeVideoChat
+    ]];
+
+    if ([kMonoModes containsObject:mode]) {
+      LOGI() << "Setting muted speech activity listener for mode: " << mode.UTF8String;
+
+      auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
+        LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
+        RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
+                  event == AVAudioVoiceProcessingSpeechActivityEnded);
+        AudioDeviceModule::SpeechActivityEvent rtc_event =
+            (event == AVAudioVoiceProcessingSpeechActivityStarted
+                ? AudioDeviceModule::SpeechActivityEvent::kStarted
+                : AudioDeviceModule::SpeechActivityEvent::kEnded);
+
+        thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
+          RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
+          if (this->observer_ != nullptr) {
+            this->observer_->OnSpeechActivityEvent(rtc_event);
+          }
+        }));
+      };
+
+      BOOL set_listener_result = [input_node setMutedSpeechActivityEventListener:listener_block];
+      if (set_listener_result) {
+        LOGI() << "setMutedSpeechActivityEventListener: listener installed successfully";
+      } else {
+        LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is videoChat or voiceChat.";
       }
+    } else {
+      BOOL set_listener_result = [input_node setMutedSpeechActivityEventListener:nil];
+      if (set_listener_result) {
+        LOGI() << "setMutedSpeechActivityEventListener: listener uninstalled successfully";
+      } 
     }
   }
 }
@@ -2695,6 +2734,28 @@ void AudioEngineDevice::UpdateAllDeviceIDs() {
 
 // ----------------------------------------------------------------------------------------------------
 // Private - Debug
+
+void AudioEngineDevice::DebugEngineState(EngineState state) {
+  RTC_DCHECK_RUN_ON(thread_);
+
+  LOGI() << "EngineState {"
+         << "IsOutputEnabled: " << state.IsOutputEnabled()
+         << ", IsInputEnabled: " << state.IsInputEnabled()
+         << ", AdvancedDucking: " << state.advanced_ducking
+         << ", DuckingLevel: " << state.ducking_level
+         << ", MuteMode: " << static_cast<int>(state.mute_mode)
+         << ", InputMuted: " << state.input_muted
+         << ", InputDeviceID: " << state.input_device_id
+         << ", OutputDeviceID: " << state.output_device_id
+         << ", VoiceProcessingEnabled: " << state.voice_processing_enabled
+         << ", VoiceProcessingBypassed: " << state.voice_processing_bypassed
+         << ", VoiceProcessingAGCEnabled: " << state.voice_processing_agc_enabled
+         << ", PrefersStereoPlayout: " << state.prefers_stereo_playout
+         << ", StereoPlayoutAvailable: " << state.stereo_playout_available
+         << ", StereoPlayoutEnabled: " << state.stereo_playout_enabled
+         << ", DesiredOutputChannels: " << state.DesiredOutputChannels()
+         << " }";
+}
 
 void AudioEngineDevice::DebugAudioEngine() {
   RTC_DCHECK_RUN_ON(thread_);

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1450,6 +1450,23 @@ int32_t AudioEngineDevice::ModifyEngineState(
     state.next.stereo_playout_available = false;
   }
 
+  // --------------------------------------------------------------------------------------------
+  // Step: Configure Stereo Playout
+  //
+
+  if (state.next.IsOutputEnabled() &&
+        (!state.prev.IsOutputEnabled() || state.IsEngineRecreateRequired())) {
+    RTC_DCHECK(!engine_device_.running);
+    
+    const uint32_t desired_channels = state.next.DesiredOutputChannels();
+    const bool applied_stereo = desired_channels >= 2;
+
+    state.next.stereo_playout_enabled = applied_stereo;
+    LOGI() << "Stereo playout optimistic update: " << applied_stereo;
+  }
+
+  UpdateVoiceProcessingForStereoState(state);
+
   // No changes, return immediately.
   if (state.HasNoChanges()) {
     LOGI() << "ModifyEngineState: No changes";
@@ -1950,6 +1967,81 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
   }
 
   // --------------------------------------------------------------------------------------------
+  // Step: Configure Voice-Processing I/O
+  //
+  if (state.next.IsInputEnabled() &&
+      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+#if TARGET_OS_SIMULATOR
+    LOGI() << "setVoiceProcessingEnabled (input): "
+           << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
+#else
+    LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
+                                                                                           : "NO";
+    NSError* error = nil;
+    BOOL set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                          error:&error];
+    if (!set_vp_result) {
+      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
+      RTC_DCHECK(set_vp_result);
+    }
+    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
+#endif
+
+    if (inputNode().voiceProcessingEnabled) {
+      // Always unmute vp if restart mute mode.
+      if (state.next.mute_mode == MuteMode::RestartEngine &&
+          inputNode().voiceProcessingInputMuted) {
+        LOGI() << "Update mute (voice processing) unmuting vp for restart engine mode";
+        inputNode().voiceProcessingInputMuted = false;
+      }
+
+      if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
+        // Muted talker detection.
+        AVAudioSession* session = [AVAudioSession sharedInstance];
+        NSString* mode = session.mode;
+        static NSSet<NSString*>* const kMonoModes = [NSSet setWithArray:@[
+          AVAudioSessionModeVoiceChat,
+          AVAudioSessionModeVideoChat
+        ]];
+
+        if ([kMonoModes containsObject:mode]) {
+          LOGI() << "Setting muted speech activity listener for mode: " << mode.UTF8String;
+
+          auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
+            LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
+            RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
+                      event == AVAudioVoiceProcessingSpeechActivityEnded);
+            AudioDeviceModule::SpeechActivityEvent rtc_event =
+                (event == AVAudioVoiceProcessingSpeechActivityStarted
+                    ? AudioDeviceModule::SpeechActivityEvent::kStarted
+                    : AudioDeviceModule::SpeechActivityEvent::kEnded);
+
+            thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
+              RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
+              if (this->observer_ != nullptr) {
+                this->observer_->OnSpeechActivityEvent(rtc_event);
+              }
+            }));
+          };
+
+          BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:listener_block];
+          if (set_listener_result) {
+            LOGI() << "setMutedSpeechActivityEventListener: listener installed successfully";
+          } else {
+            LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is videoChat or voiceChat.";
+          }
+        } else {
+          BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:nil];
+          if (set_listener_result) {
+            LOGI() << "setMutedSpeechActivityEventListener: listener uninstalled successfully";
+          } 
+        }
+      }
+    }
+  }
+
+
+  // --------------------------------------------------------------------------------------------
   // Step: Enable output
   //
   if (state.next.IsOutputEnabled() &&
@@ -1958,6 +2050,12 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     RTC_DCHECK(!engine_device_.running);
 
     AVAudioFormat* output_node_format = [outputNode() outputFormatForBus:0];
+
+    // Duplicate from the Configure StereoPlayout step above to get correct format after engine recreate.
+    const uint32_t desired_channels = state.next.DesiredOutputChannels();
+    const uint32_t hardware_channels =
+        static_cast<uint32_t>(std::max<NSInteger>(1, output_node_format.channelCount));
+    const uint32_t applied_channels = std::min(desired_channels, hardware_channels);
 
     LOGI() << "Output format sampleRate: " << output_node_format.sampleRate
            << " channels: " << output_node_format.channelCount
@@ -1973,21 +2071,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
       LOGE() << "Output device not available, sampleRate=" << output_node_format.sampleRate
              << ", channelCount=" << output_node_format.channelCount;
       return rollback(kAudioEnginePlayoutDeviceNotAvailableError);
-    }
-
-    const uint32_t desired_channels = state.next.DesiredOutputChannels();
-    const uint32_t hardware_channels =
-        static_cast<uint32_t>(std::max<NSInteger>(1, output_node_format.channelCount));
-    const uint32_t applied_channels = std::min(desired_channels, hardware_channels);
-    const bool applied_stereo = applied_channels >= 2;
-
-    state.next.stereo_playout_enabled = applied_stereo;
-    if (desired_channels >= 2 && !applied_stereo) {
-      LOGW() << "Stereo requested but hardware is mono; falling back to 1 channel.";
-    } else {
-      LOGI() << "Applied output channel count: " << applied_channels 
-             << " (desired: " << desired_channels
-             << ", hardware: " << hardware_channels << ")";
     }
 
     AVAudioFormat* engine_output_format = [[AVAudioFormat alloc]
@@ -2060,12 +2143,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     AVAudioFormat* mixer_format = [engine_device_.mainMixerNode outputFormatForBus:0];
     if (mixer_format.channelCount < applied_channels) {
       LOGW() << "Mixer forced channel count to " << mixer_format.channelCount;
-      state.next.stereo_playout_enabled = mixer_format.channelCount >= 2;
     } else {
       LOGI() << "Mixer accepted channel count to " << mixer_format.channelCount;
     }
-           
-    UpdateVoiceProcessingForStereoState(state);
 
     if (this->observer_ != nullptr) {
       NSDictionary* context = @{};
@@ -2097,11 +2177,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
       source_node_ = nil;
     }
   }
-
-  // --------------------------------------------------------------------------------------------
-  // Step: Configure Voice-Processing I/O
-  //
-  ConfigureVoiceProcessingNode(inputNode(), state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Enable input

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -672,6 +672,10 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
 
   return ModifyEngineState([enable](EngineState state) {
     state.prefers_stereo_playout = enable;
+    if (enable) {
+      state.voice_processing_enabled = false;
+      state.voice_processing_agc_enabled = false;
+    }
     return state;
   });
 }
@@ -754,88 +758,6 @@ int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& s
 #endif
 
   return 0;
-}
-
-bool AudioEngineDevice::ManualRestoreVoiceProcessingOnMono() const {
-  RTC_DCHECK_RUN_ON(thread_);
-  return manual_restore_voice_processing_on_mono_;
-}
-
-void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restore) {
-  RTC_DCHECK_RUN_ON(thread_);
-  if (manual_restore_voice_processing_on_mono_ == manual_restore) {
-    return;
-  }
-
-  manual_restore_voice_processing_on_mono_ = manual_restore;
-
-  // Re-run the state machine so the VP override is applied or rolled back
-  ModifyEngineState([](EngineState state) { return state; });
-}
-
-void AudioEngineDevice::UpdateVoiceProcessingForStereoState(EngineStateUpdate& state) {
-  const bool didUpdateStereoPlayoutEnabled = 
-      state.prev.stereo_playout_enabled != state.next.stereo_playout_enabled;
-  const bool enabling_stereo = !state.prev.stereo_playout_enabled && state.next.stereo_playout_enabled;
-  const bool disabling_stereo = state.prev.stereo_playout_enabled && !state.next.stereo_playout_enabled;
-
-  LOGI() << "UpdateVoiceProcessingForStereoState: { "
-         << " didUpdateStereoPlayoutEnabled: " << didUpdateStereoPlayoutEnabled
-         << ", enabling_stereo: " << enabling_stereo
-         << ", disabling_stereo: " << disabling_stereo
-         << ", stereo_voice_processing_override_active_: " << stereo_voice_processing_override_active_
-         << ", manual_restore_voice_processing_on_mono_: " << manual_restore_voice_processing_on_mono_
-         << " }";
-
-  if (state.next.stereo_playout_enabled) {
-    if (!stereo_voice_processing_override_active_) {
-      stereo_voice_processing_override_active_ = true;
-      stereo_saved_voice_processing_enabled_ = state.prev.voice_processing_enabled;
-      stereo_saved_voice_processing_bypassed_ = state.prev.voice_processing_bypassed;
-      stereo_saved_voice_processing_agc_enabled_ = state.prev.voice_processing_agc_enabled;
-      LOGI() << "Saving VP state for stereo override: { "
-              << " voice_processing_enabled: " << stereo_saved_voice_processing_enabled_
-              << ", voice_processing_bypassed: " << stereo_saved_voice_processing_bypassed_
-              << ", voice_processing_agc_enabled: " << stereo_saved_voice_processing_agc_enabled_
-              << " }";
-    }
-
-    if (state.next.voice_processing_enabled || state.next.voice_processing_agc_enabled) {
-      // Force VP/AGC into the disabled state required for stereo
-      state.next.voice_processing_enabled = false;
-      state.next.voice_processing_bypassed = true;
-      state.next.voice_processing_agc_enabled = false;
-      LOGI() << "Disabling VP/AGC for stereo playback";
-    }
-  } else {
-    if (stereo_voice_processing_override_active_) {
-      state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-      state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
-      state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
-      stereo_voice_processing_override_active_ = false;
-      
-      LOGI() << "Restoring VP state from stereo override: { "
-              << " voice_processing_enabled: " << stereo_saved_voice_processing_enabled_
-              << ", voice_processing_bypassed: " << stereo_saved_voice_processing_bypassed_
-              << ", voice_processing_agc_enabled: " << stereo_saved_voice_processing_agc_enabled_
-              << " }";
-    } else {
-      if (!state.next.voice_processing_enabled) {
-        // We recover VP from the default state
-        EngineState initial_state;
-        state.next.voice_processing_enabled = initial_state.voice_processing_enabled;
-        state.next.voice_processing_bypassed = initial_state.voice_processing_bypassed;
-        state.next.voice_processing_agc_enabled = initial_state.voice_processing_agc_enabled;
-        LOGI() << "Restoring VP state from default: { "
-                << " voice_processing_enabled: " << state.next.voice_processing_enabled
-                << ", voice_processing_bypassed: " << state.next.voice_processing_bypassed
-                << ", voice_processing_agc_enabled: " << state.next.voice_processing_agc_enabled
-                << " }";
-      }
-    }
-  }
-
-  DebugEngineState("UpdateVoiceProcessingForStereoState: Completed", state.next);
 }
 
 void AudioEngineDevice::RefreshStereoPlayoutState() {
@@ -1234,6 +1156,11 @@ int32_t AudioEngineDevice::SetVoiceProcessingEnabled(bool enable) {
   RTC_DCHECK_RUN_ON(thread_);
   LOGI() << "SetVoiceProcessingEnabled: " << enable;
 
+  if (enable && engine_state_.prefers_stereo_playout) {
+    LOGI() << "SetVoiceProcessingEnabled: Overriding to false due to stereo playout preference.";
+    enable = false;
+  }
+
   int32_t result = ModifyEngineState([enable](EngineState state) -> EngineState {
     state.voice_processing_enabled = enable;
     return state;
@@ -1283,6 +1210,11 @@ int32_t AudioEngineDevice::VoiceProcessingAGCEnabled(bool* enabled) {
 int32_t AudioEngineDevice::SetVoiceProcessingAGCEnabled(bool enable) {
   RTC_DCHECK_RUN_ON(thread_);
   LOGI() << "SetVoiceProcessingAGCEnabled: " << enable;
+
+  if (enable && engine_state_.prefers_stereo_playout) {
+    LOGI() << "SetVoiceProcessingAGCEnabled: Overriding to false due to stereo playout preference.";
+    enable = false;
+  }
 
   int32_t result = ModifyEngineState([enable](EngineState state) -> EngineState {
     state.voice_processing_agc_enabled = enable;
@@ -1496,14 +1428,6 @@ void AudioEngineDevice::ResetEngineState() {
     LOGE() << "ResetEngineState: failed to reset engine state, error: " << result;
     return;
   }
-
-  // Clear the stereo override bookkeeping; the current engine_state_ has already been
-  // updated by ModifyEngineState so we can seed our caches from it.
-  stereo_voice_processing_override_active_ = false;
-  stereo_saved_voice_processing_enabled_ = engine_state_.voice_processing_enabled;
-  stereo_saved_voice_processing_bypassed_ = engine_state_.voice_processing_bypassed;
-  stereo_saved_voice_processing_agc_enabled_ = engine_state_.voice_processing_agc_enabled;
-  manual_restore_voice_processing_on_mono_ = false;
 }
 
 int32_t AudioEngineDevice::ModifyEngineState(
@@ -1800,7 +1724,6 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate& state) {
     audio_device_buffer_->SetPlayoutChannels(manual_render_rtc_format_.channelCount);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
-    UpdateVoiceProcessingForStereoState(state);
     ConfigureVoiceProcessingNode(engine_manual_input_.inputNode, state);
 
   } else if (state.prev.IsOutputEnabled() && !state.next.IsOutputEnabled()) {
@@ -2061,6 +1984,13 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
   }
 
   // --------------------------------------------------------------------------------------------
+  // Step: Configure Voice-Processing I/O
+  //
+  // - Note: We configure input VP before output to avoid artifacts playout during configuration.
+  //
+  ConfigureVoiceProcessingNode(inputNode(), state);
+
+  // --------------------------------------------------------------------------------------------
   // Step: Enable output
   //
   if (state.next.IsOutputEnabled() &&
@@ -2200,12 +2130,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
       source_node_ = nil;
     }
   }
-
-  // --------------------------------------------------------------------------------------------
-  // Step: Configure Voice-Processing I/O
-  //
-  UpdateVoiceProcessingForStereoState(state);
-  ConfigureVoiceProcessingNode(inputNode(), state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Enable input

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -483,6 +483,8 @@ void AudioEngineDevice::OnInterruptionEnd(bool should_resume) {
 void AudioEngineDevice::OnValidRouteChange() {
   LOGI() << "OnValidRouteChange";
   RTC_DCHECK(thread_);
+
+  RefreshStereoPlayoutState();
 }
 
 void AudioEngineDevice::OnCanPlayOrRecordChange(bool can_play_or_record) {
@@ -659,6 +661,8 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
 }
 
 int32_t AudioEngineDevice::StereoPlayout(bool* enabled) const {
+  RTC_DCHECK_RUN_ON(thread_);
+  
   bool stereo_playout_enabled = engine_state_.stereo_playout_enabled;
   LOGI() << "StereoPlayout: " << stereo_playout_enabled;
 
@@ -734,6 +738,71 @@ int32_t AudioEngineDevice::ResolveStereoPlayoutAvailability(const EngineState& s
 #endif
 
   return 0;
+}
+
+bool AudioEngineDevice::ManualRestoreVoiceProcessingOnMono() const {
+  RTC_DCHECK_RUN_ON(thread_);
+  return manual_restore_voice_processing_on_mono_;
+}
+
+void AudioEngineDevice::SetManualRestoreVoiceProcessingOnMono(bool manual_restore) {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (manual_restore_voice_processing_on_mono_ == manual_restore) {
+    return;
+  }
+
+  manual_restore_voice_processing_on_mono_ = manual_restore;
+
+  // Re-run the state machine so the VP override is applied or rolled back
+  ModifyEngineState([](EngineState state) { return state; });
+}
+
+void AudioEngineDevice::UpdateVoiceProcessingForStereoState(const EngineState& prev,
+                                                            EngineState& next) {
+  const bool enabling_stereo = !prev.stereo_playout_enabled && next.stereo_playout_available;
+  const bool disabling_stereo = prev.stereo_playout_enabled && !next.stereo_playout_available;
+
+  if (enabling_stereo) {
+    if (!stereo_voice_processing_override_active_) {
+      stereo_voice_processing_override_active_ = true;
+      stereo_saved_voice_processing_enabled_ = prev.voice_processing_enabled;
+      stereo_saved_voice_processing_bypassed_ = prev.voice_processing_bypassed;
+      stereo_saved_voice_processing_agc_enabled_ = prev.voice_processing_agc_enabled;
+    }
+
+    // Force VP/AGC into the disabled state required for stereo
+    next.voice_processing_enabled = false;
+    next.voice_processing_bypassed = true;
+    next.voice_processing_agc_enabled = false;
+    return;
+  }
+
+  if (disabling_stereo && stereo_voice_processing_override_active_) {
+    if (!manual_restore_voice_processing_on_mono_) {
+      next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+      next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+      next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
+      stereo_voice_processing_override_active_ = false;
+    }
+    // If manual_restore_voice_processing_on_mono_ is true, we leave the saved values
+    // untouched so the user can decide when to re-enable VP/AGC.
+  }
+}
+
+void AudioEngineDevice::RefreshStereoPlayoutState() {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (!engine_state_.prefers_stereo_playout) {
+    return;
+  }
+
+  int32_t result = ModifyEngineState([](EngineState state) -> EngineState {
+    return state;
+  });
+  if (result != 0) {
+    LOGE() << "Failed to refresh stereo playout & engine state, error: " << result;
+  } else {
+    LOGI() << "Refreshed stereo playout & engine state";
+  }
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -1373,6 +1442,15 @@ int32_t AudioEngineDevice::ModifyEngineState(
   EngineState new_state = state_transform(old_state);
   EngineStateUpdate state = {old_state, new_state};
 
+  // Evaluate stereo playout availability for new state.
+  bool stereo_available = false;
+  if (ResolveStereoPlayoutAvailability(state.next, &stereo_available) == 0) {
+    state.next.stereo_playout_available = state.next.prefers_stereo_playout && stereo_available;
+  } else {
+    LOGE() << "ModifyEngineState: Failed to resolve stereo playout availability";
+    state.next.stereo_playout_available = false;
+  }
+
   // No changes, return immediately.
   if (state.HasNoChanges()) {
     return 0;
@@ -1569,10 +1647,25 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
     LOGI() << "Enabling output for AVAudioEngine...";
     RTC_DCHECK(!engine_manual_input_.running);
 
+    const uint32_t desired_channels = state.next.DesiredOutputChannels();
+    // Manual mode controls its own graph, so clamp only to ≥1.
+    const uint32_t applied_channels = std::max<uint32_t>(1, desired_channels);
+    state.next.stereo_playout_enabled = applied_channels >= 2;
+    if (desired_channels >= 2 && !state.next.stereo_playout_enabled) {
+      LOGW() << "Manual mode requested stereo but fell back to mono.";
+    }
+
+    manual_render_rtc_format_ = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
+                                                                 sampleRate:48000
+                                                                   channels:applied_channels
+                                                                interleaved:YES];
+
     audio_device_buffer_->SetPlayoutSampleRate(manual_render_rtc_format_.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(manual_render_rtc_format_.channelCount);
-    RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
+
+    UpdateVoiceProcessingForStereoState(state.prev, state.next);
+    ConfigureVoiceProcessingNode(engine_manual_input_.inputNode, state);
 
   } else if (state.prev.IsOutputEnabled() && !state.next.IsOutputEnabled()) {
     LOGI() << "Disabling output for AVAudioEngine...";
@@ -1584,7 +1677,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
     RTC_DCHECK(!engine_manual_input_.running);
 
     audio_device_buffer_->SetRecordingSampleRate(manual_render_rtc_format_.sampleRate);
-    audio_device_buffer_->SetRecordingChannels(manual_render_rtc_format_.channelCount);
+    audio_device_buffer_->SetRecordingChannels(1);  // Always mono for input
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -1834,61 +1927,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
   // --------------------------------------------------------------------------------------------
   // Step: Configure Voice-Processing I/O
   //
-  if (state.next.IsInputEnabled() &&
-      inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-#if TARGET_OS_SIMULATOR
-    LOGI() << "setVoiceProcessingEnabled (input): "
-           << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
-#else
-    LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
-                                                                                           : "NO";
-    NSError* error = nil;
-    BOOL set_vp_result = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                          error:&error];
-    if (!set_vp_result) {
-      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
-      RTC_DCHECK(set_vp_result);
-    }
-    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
-#endif
-
-    if (inputNode().voiceProcessingEnabled) {
-      // Always unmute vp if restart mute mode.
-      if (state.next.mute_mode == MuteMode::RestartEngine &&
-          inputNode().voiceProcessingInputMuted) {
-        LOGI() << "Update mute (voice processing) unmuting vp for restart engine mode";
-        inputNode().voiceProcessingInputMuted = false;
-      }
-
-      // Muted talker detection.
-      if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
-        auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
-          LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
-          RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
-                     event == AVAudioVoiceProcessingSpeechActivityEnded);
-          AudioDeviceModule::SpeechActivityEvent rtc_event =
-              (event == AVAudioVoiceProcessingSpeechActivityStarted
-                   ? AudioDeviceModule::SpeechActivityEvent::kStarted
-                   : AudioDeviceModule::SpeechActivityEvent::kEnded);
-
-          thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
-            RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
-            if (this->observer_ != nullptr) {
-              this->observer_->OnSpeechActivityEvent(rtc_event);
-            }
-          }));
-        };
-
-        BOOL set_listener_result = [inputNode() setMutedSpeechActivityEventListener:listener_block];
-        if (set_listener_result) {
-          LOGI() << "setMutedSpeechActivityEventListener success";
-        } else {
-          LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is "
-                    "videoChat or voiceChat.";
-        }
-      }
-    }
-  }
+  ConfigureVoiceProcessingNode(inputNode(), state);
 
   // --------------------------------------------------------------------------------------------
   // Step: Enable output
@@ -1916,11 +1955,32 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
       return rollback(kAudioEnginePlayoutDeviceNotAvailableError);
     }
 
+    const uint32_t desired_channels = state.next.DesiredOutputChannels();
+    const uint32_t hardware_channels =
+        static_cast<uint32_t>(std::max<NSInteger>(1, output_node_format.channelCount));
+    const uint32_t applied_channels = std::min(desired_channels, hardware_channels);
+    const bool applied_stereo = applied_channels >= 2;
+
+    state.next.stereo_playout_enabled = applied_stereo;
+    if (desired_channels >= 2 && !applied_stereo) {
+      LOGW() << "Stereo requested but hardware is mono; falling back to 1 channel.";
+    }
+
     AVAudioFormat* engine_output_format = [[AVAudioFormat alloc]
         initWithCommonFormat:output_node_format.commonFormat  // Usually float32
                   sampleRate:output_node_format.sampleRate
-                    channels:1
+                    channels:applied_channels
                  interleaved:output_node_format.interleaved];
+
+    LOGI() << "New engine output format sampleRate: " << engine_output_format.sampleRate
+           << " channels: " << engine_output_format.channelCount
+           << " formatID: " << engine_output_format.streamDescription->mFormatID
+           << " formatFlags: " << engine_output_format.streamDescription->mFormatFlags
+           << " bytesPerPacket: " << engine_output_format.streamDescription->mBytesPerPacket
+           << " framesPerPacket: " << engine_output_format.streamDescription->mFramesPerPacket
+           << " bytesPerFrame: " << engine_output_format.streamDescription->mBytesPerFrame
+           << " channelsPerFrame: " << engine_output_format.streamDescription->mChannelsPerFrame
+           << " bitsPerChannel: " << engine_output_format.streamDescription->mBitsPerChannel;
 
     audio_device_buffer_->SetPlayoutSampleRate(engine_output_format.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(engine_output_format.channelCount);
@@ -1930,8 +1990,18 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     AVAudioFormat* rtc_output_format =
         [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
                                          sampleRate:engine_output_format.sampleRate
-                                           channels:1
+                                           channels:engine_output_format.channelCount
                                         interleaved:YES];
+
+    LOGI() << "New RTC output format sampleRate: " << rtc_output_format.sampleRate
+           << " channels: " << rtc_output_format.channelCount
+           << " formatID: " << rtc_output_format.streamDescription->mFormatID
+           << " formatFlags: " << rtc_output_format.streamDescription->mFormatFlags
+           << " bytesPerPacket: " << rtc_output_format.streamDescription->mBytesPerPacket
+           << " framesPerPacket: " << rtc_output_format.streamDescription->mFramesPerPacket
+           << " bytesPerFrame: " << rtc_output_format.streamDescription->mBytesPerFrame
+           << " channelsPerFrame: " << rtc_output_format.streamDescription->mChannelsPerFrame
+           << " bitsPerChannel: " << rtc_output_format.streamDescription->mBitsPerChannel;
 
     AVAudioSourceNodeRenderBlock source_block =
         ^OSStatus(BOOL* isSilence, const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount,
@@ -1940,8 +2010,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 
           int16_t* dest_buffer = (int16_t*)outputData->mBuffers[0].mData;
 
+          const size_t samples = frameCount * applied_channels;
           fine_audio_buffer_->GetPlayoutData(
-              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer), frameCount),
+              webrtc::ArrayView<int16_t>(static_cast<int16_t*>(dest_buffer), samples),
               kFixedPlayoutDelayEstimate);
 
           return noErr;
@@ -1960,6 +2031,19 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
     [engine_device_ connect:engine_device_.mainMixerNode
                          to:outputNode()
                      format:engine_output_format];
+
+    // Confirm the mixer honored our channel count
+    AVAudioFormat* mixer_format = [engine_device_.mainMixerNode outputFormatForBus:0];
+    if (mixer_format.channelCount < applied_channels) {
+      LOGW() << "Mixer forced channel count to " << mixer_format.channelCount;
+      state.next.stereo_playout_enabled = mixer_format.channelCount >= 2;
+    } else {
+      LOGI() << "Mixer accepted channel count to " << mixer_format.channelCount;
+    }
+    
+    LOGI() << "Updating VoiceProcessing state from the updated output configuration...";
+    UpdateVoiceProcessingForStereoState(state.prev, state.next);
+    ConfigureVoiceProcessingNode(inputNode(), state);
 
     if (this->observer_ != nullptr) {
       NSDictionary* context = @{};
@@ -2429,12 +2513,76 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state) {
 // ----------------------------------------------------------------------------------------------------
 // Private - EngineState
 
+void AudioEngineDevice::ConfigureVoiceProcessingNode(AVAudioInputNode* input_node,
+                                                     const EngineStateUpdate& state) {
+  RTC_DCHECK_RUN_ON(thread_);
+
+  if (state.next.IsInputEnabled() &&
+      input_node.voiceProcessingEnabled != state.next.voice_processing_enabled) {
+#if TARGET_OS_SIMULATOR
+    LOGI() << "setVoiceProcessingEnabled (input): "
+           << (state.next.voice_processing_enabled ? "YES" : "NO") << " (Ignored on Simulator)";
+#else
+    LOGI() << "setVoiceProcessingEnabled (input): " << state.next.voice_processing_enabled ? "YES"
+                                                                                           : "NO";
+    NSError* error = nil;
+    BOOL set_vp_result = [input_node setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                          error:&error];
+    if (!set_vp_result) {
+      NSLog(@"AudioEngineDevice setVoiceProcessingEnabled error: %@", error.localizedDescription);
+      RTC_DCHECK(set_vp_result);
+    }
+    LOGI() << "setVoiceProcessingEnabled (input) result: " << set_vp_result ? "YES" : "NO";
+#endif
+
+    if (input_node.voiceProcessingEnabled) {
+      // Always unmute vp if restart mute mode.
+      if (state.next.mute_mode == MuteMode::RestartEngine &&
+          input_node.voiceProcessingInputMuted) {
+        LOGI() << "Update mute (voice processing) unmuting vp for restart engine mode";
+        input_node.voiceProcessingInputMuted = false;
+      }
+
+      // Muted talker detection.
+      if (@available(iOS 17.0, macCatalyst 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, *)) {
+        auto listener_block = ^(AVAudioVoiceProcessingSpeechActivityEvent event) {
+          LOGI() << "AVAudioVoiceProcessingSpeechActivityEvent: " << event;
+          RTC_DCHECK(event == AVAudioVoiceProcessingSpeechActivityStarted ||
+                     event == AVAudioVoiceProcessingSpeechActivityEnded);
+          AudioDeviceModule::SpeechActivityEvent rtc_event =
+              (event == AVAudioVoiceProcessingSpeechActivityStarted
+                   ? AudioDeviceModule::SpeechActivityEvent::kStarted
+                   : AudioDeviceModule::SpeechActivityEvent::kEnded);
+
+          thread_->PostTask(SafeTask(safety_, [this, rtc_event] {
+            RTC_DCHECK_RUN_ON(thread_);  // Silence warning.
+            if (this->observer_ != nullptr) {
+              this->observer_->OnSpeechActivityEvent(rtc_event);
+            }
+          }));
+        };
+
+        BOOL set_listener_result = [input_node setMutedSpeechActivityEventListener:listener_block];
+        if (set_listener_result) {
+          LOGI() << "setMutedSpeechActivityEventListener success";
+        } else {
+          LOGW() << "setMutedSpeechActivityEventListener failed, ensure AVAudioSession.Mode is "
+                    "videoChat or voiceChat.";
+        }
+      }
+    }
+  }
+}
+
 void AudioEngineDevice::StartRenderLoop() {
   RTC_DCHECK_RUN_ON(render_thread_.get());
 
+  const uint32_t channels = manual_render_rtc_format_.channelCount;
   const double sample_rate = manual_render_rtc_format_.sampleRate;
   const size_t frames_per_buffer = static_cast<size_t>(sample_rate / 100);  // 10ms chunks
-  const size_t buffer_size = frames_per_buffer * kAudioSampleSize;
+  // We update the sample number to match the frames per channel.
+  const size_t samples = frames_per_buffer * channels;
+  const size_t buffer_size = samples * kAudioSampleSize;
   const int chunk_ms =
       static_cast<int>(std::round(1000.0 * static_cast<double>(frames_per_buffer) / sample_rate));
   int64_t next_wakeup_ms = rtc::TimeMillis();
@@ -2451,7 +2599,7 @@ void AudioEngineDevice::StartRenderLoop() {
 
     // Call GetPlayoutData to pull frames into rtc audio stack even though we won't use it here.
     fine_audio_buffer_->GetPlayoutData(
-        webrtc::ArrayView<int16_t>(read_rtc_buffer, frames_per_buffer), kFixedPlayoutDelayEstimate);
+        webrtc::ArrayView<int16_t>(read_rtc_buffer, samples), kFixedPlayoutDelayEstimate);
 
     // Render (Input)
     RTC_DCHECK(render_buffer_ != nullptr);

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -90,6 +90,7 @@ AudioEngineDevice::AudioEngineDevice(bool voice_processing_bypassed)
   stereo_voice_processing_override_active_ = false;
   stereo_saved_voice_processing_enabled_ = true;
   stereo_saved_voice_processing_bypassed_ = false;
+  stereo_saved_voice_processing_agc_enabled_ = true;
 }
 
 AudioEngineDevice::~AudioEngineDevice() {
@@ -737,6 +738,7 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
 
   const bool vp_enabled_before = engine_state_.voice_processing_enabled;
   const bool vp_bypassed_before = engine_state_.voice_processing_bypassed;
+  const bool vp_agc_enabled_before = engine_state_.voice_processing_agc_enabled;
   const bool apply_vp_override = enable && vp_enabled_before;
 
   if (enable && apply_vp_override) {
@@ -749,11 +751,13 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
       if (apply_vp_override) {
         state.voice_processing_enabled = false;
         state.voice_processing_bypassed = false;
+        state.voice_processing_agc_enabled = false;
       }
     } else {
       if (stereo_voice_processing_override_active_) {
         state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
         state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+        state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
       }
     }
     return state;
@@ -768,6 +772,7 @@ int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
       stereo_voice_processing_override_active_ = true;
       stereo_saved_voice_processing_enabled_ = vp_enabled_before;
       stereo_saved_voice_processing_bypassed_ = vp_bypassed_before;
+      stereo_saved_voice_processing_agc_enabled_ = vp_agc_enabled_before;
     }
   } else {
     if (stereo_voice_processing_override_active_) {
@@ -1107,8 +1112,24 @@ int32_t AudioEngineDevice::EnableBuiltInNS(bool enable) { return -1; }
 // Misc
 
 #if defined(WEBRTC_IOS)
-int AudioEngineDevice::GetPlayoutAudioParameters(AudioParameters* params) const { return -1; }
-int AudioEngineDevice::GetRecordAudioParameters(AudioParameters* params) const { return -1; }
+int AudioEngineDevice::GetPlayoutAudioParameters(AudioParameters* params) const {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (params == nullptr) {
+    return -1;
+  }
+
+  *params = playout_parameters_;
+  return params->is_valid() ? 0 : -1;
+}
+int AudioEngineDevice::GetRecordAudioParameters(AudioParameters* params) const {
+  RTC_DCHECK_RUN_ON(thread_);
+  if (params == nullptr) {
+    return -1;
+  }
+
+  *params = record_parameters_;
+  return params->is_valid() ? 0 : -1;
+}
 #endif
 
 int32_t AudioEngineDevice::PlayoutDelay(uint16_t* delayMS) const {
@@ -1415,6 +1436,7 @@ void AudioEngineDevice::ReconfigureEngine() {
           } else {
             current_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
             current_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+            current_state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
           }
           stereo_voice_processing_override_active_ = false;
         }
@@ -1479,6 +1501,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
         route_restore_voice_processing = true;
         state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
         state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+        state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
       }
     }
   }
@@ -1576,6 +1599,7 @@ int32_t AudioEngineDevice::ModifyEngineState(
       LOGW() << "Restoring voice processing after stereo fallback";
       new_state.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
       new_state.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+      new_state.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
       stereo_voice_processing_override_active_ = false;
     }
 
@@ -1710,6 +1734,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
 
     audio_device_buffer_->SetPlayoutSampleRate(manual_render_rtc_format_.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(manual_render_rtc_format_.channelCount);
+    playout_parameters_.reset(manual_render_rtc_format_.sampleRate, manual_render_rtc_format_.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -1724,6 +1749,7 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate state) {
 
     audio_device_buffer_->SetRecordingSampleRate(manual_render_rtc_format_.sampleRate);
     audio_device_buffer_->SetRecordingChannels(manual_render_rtc_format_.channelCount);
+    record_parameters_.reset(manual_render_rtc_format_.sampleRate, manual_render_rtc_format_.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -2082,16 +2108,17 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
       if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
         *stereo_playout_reset = true;
       }
-      if (restore_voice_processing && state.next.stereo_playout_enabled &&
-          stereo_voice_processing_override_active_) {
-        *restore_voice_processing = true;
-        state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-        state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+        if (restore_voice_processing && state.next.stereo_playout_enabled &&
+            stereo_voice_processing_override_active_) {
+          *restore_voice_processing = true;
+          state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+          state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+          state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
 #if !TARGET_OS_SIMULATOR
-        if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-          NSError* vp_error = nil;
-          BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                        error:&vp_error];
+          if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+            NSError* vp_error = nil;
+            BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                          error:&vp_error];
           if (!set_vp) {
             LOGE() << "Failed to restore voice processing: "
                    << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
@@ -2114,15 +2141,16 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
     } else if (stereo_playout_reset && requested_channels < 2 && state.next.stereo_playout_enabled) {
       // Handle cases where desired stereo was set but route currently only reports mono channels.
       *stereo_playout_reset = true;
-      if (restore_voice_processing && stereo_voice_processing_override_active_) {
-        *restore_voice_processing = true;
-        state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
-        state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+        if (restore_voice_processing && stereo_voice_processing_override_active_) {
+          *restore_voice_processing = true;
+          state.next.voice_processing_enabled = stereo_saved_voice_processing_enabled_;
+          state.next.voice_processing_bypassed = stereo_saved_voice_processing_bypassed_;
+          state.next.voice_processing_agc_enabled = stereo_saved_voice_processing_agc_enabled_;
 #if !TARGET_OS_SIMULATOR
-        if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
-          NSError* vp_error = nil;
-          BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
-                                                        error:&vp_error];
+          if (inputNode().voiceProcessingEnabled != state.next.voice_processing_enabled) {
+            NSError* vp_error = nil;
+            BOOL set_vp = [inputNode() setVoiceProcessingEnabled:state.next.voice_processing_enabled
+                                                          error:&vp_error];
           if (!set_vp) {
             LOGE() << "Failed to restore voice processing: "
                    << (vp_error ? vp_error.localizedDescription.UTF8String : "unknown");
@@ -2149,9 +2177,13 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
                   sampleRate:output_node_format.sampleRate
                     channels:requested_channels
                  interleaved:output_node_format.interleaved];
+    LOGI() << "Engine output format sampleRate=" << engine_output_format.sampleRate
+           << ", channels=" << engine_output_format.channelCount
+           << ", interleaved=" << (engine_output_format.interleaved ? "YES" : "NO");
 
     audio_device_buffer_->SetPlayoutSampleRate(engine_output_format.sampleRate);
     audio_device_buffer_->SetPlayoutChannels(engine_output_format.channelCount);
+    playout_parameters_.reset(engine_output_format.sampleRate, engine_output_format.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
@@ -2160,6 +2192,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
                                          sampleRate:engine_output_format.sampleRate
                                            channels:requested_channels
                                         interleaved:YES];
+    LOGI() << "RTC output format sampleRate=" << rtc_output_format.sampleRate
+           << ", channels=" << rtc_output_format.channelCount
+           << ", interleaved=" << (rtc_output_format.interleaved ? "YES" : "NO");
 
     AVAudioSourceNodeRenderBlock source_block =
         ^OSStatus(BOOL* isSilence, const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount,
@@ -2276,6 +2311,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate state,
 
     audio_device_buffer_->SetRecordingSampleRate(rtc_input_format.sampleRate);
     audio_device_buffer_->SetRecordingChannels(rtc_input_format.channelCount);
+    record_parameters_.reset(rtc_input_format.sampleRate, rtc_input_format.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1984,6 +1984,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     state.next.stereo_playout_enabled = applied_stereo;
     if (desired_channels >= 2 && !applied_stereo) {
       LOGW() << "Stereo requested but hardware is mono; falling back to 1 channel.";
+    } else {
+      LOGI() << "Applied output channel count: " << applied_channels 
+             << " (desired: " << desired_channels
+             << ", hardware: " << hardware_channels << ")";
     }
 
     AVAudioFormat* engine_output_format = [[AVAudioFormat alloc]

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -650,20 +650,23 @@ int32_t AudioEngineDevice::StereoPlayoutIsAvailable(bool* available) const {
 }
 
 int32_t AudioEngineDevice::SetStereoPlayout(bool enable) {
-  LOGW() << "SetStereoPlayout: Not implemented, value:" << enable;
+  RTC_DCHECK_RUN_ON(thread_);
 
-  audio_device_buffer_->SetPlayoutChannels(1);
-
-  return 0;
+  return ModifyEngineState([enable](EngineState state) {
+    state.prefers_stereo_playout = enable;
+    return state;
+  });
 }
 
 int32_t AudioEngineDevice::StereoPlayout(bool* enabled) const {
-  LOGI() << "StereoPlayout";
+  bool stereo_playout_enabled = engine_state_.stereo_playout_enabled;
+  LOGI() << "StereoPlayout: " << stereo_playout_enabled;
+
   if (enabled == nullptr) {
     return -1;
   }
-
-  *enabled = false;
+  
+  *enabled = stereo_playout_enabled;
 
   return 0;
 }

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -72,6 +72,12 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
     : (RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule didReceiveSpeechActivityEvent
     : (RTC_OBJC_TYPE(RTCSpeechActivityEvent))speechActivityEvent NS_SWIFT_NAME(audioDeviceModule(_:didReceiveSpeechActivityEvent:));
 
+// Stereo
+
+- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+      isStereoPlayoutAvailable:(BOOL)isStereoPlayoutAvailable
+    NS_SWIFT_NAME(audioDeviceModule(_:isStereoPlayoutAvailable:));
+
 // Engine events
 - (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
                didCreateEngine:(AVAudioEngine *)engine
@@ -129,6 +135,10 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
     didChangeProperty:(RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty))property
              newValue:(BOOL)newValue
     NS_SWIFT_NAME(audioDeviceModule(_:didChangeProperty:newValue:));
+
+- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+    didUpdateStereoPlayoutAvailability:(BOOL)isAvailable
+    NS_SWIFT_NAME(audioDeviceModule(_:didUpdateStereoPlayoutAvailability:));
 
 @end
 
@@ -206,7 +216,9 @@ RTC_OBJC_EXPORT
 - (NSInteger)setVoiceProcessingAGCEnabled:(BOOL)enabled;
 
 /// When enabled, the app is responsible for re-enabling Voice-Processing I/O after a mono-only
-/// route forces stereo playout off. Defaults to NO (auto-restore).
+/// route forces stereo playout off. Changing `AVAudioSession.mode` alone is not enough—call
+/// `setVoiceProcessingEnabled:YES` (and optionally `setVoiceProcessingBypassed:`) once you want to
+/// bring the VoiceProcessingIO path back. Defaults to NO (auto-restore).
 @property(nonatomic, assign) BOOL manualRestoreVoiceProcessingOnMono;
 
 /// Indicates whether stereo playout can currently be enabled. Returns NO when only mono output is

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -49,12 +49,24 @@ typedef struct {
   RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
 } RTC_OBJC_TYPE(RTCAudioEngineState);
 
+typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty)) {
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyMicrophoneMuted),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyRecordingAlwaysPreparedMode),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyManualRenderingMode),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingEnabled),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingBypassed),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingAGCEnabled),
+  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyStereoPlayoutEnabled)
+};
+
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
 @class RTC_OBJC_TYPE(RTCAudioDeviceModule);
 
 RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 (RTCAudioDeviceModuleDelegate)<NSObject>
+
+@required
 
     - (void)audioDeviceModule
     : (RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule didReceiveSpeechActivityEvent
@@ -111,6 +123,12 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 
 - (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
     NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
+
+@optional
+- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+    didChangeProperty:(RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty))property
+             newValue:(BOOL)newValue
+    NS_SWIFT_NAME(audioDeviceModule(_:didChangeProperty:newValue:));
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -205,6 +205,10 @@ RTC_OBJC_EXPORT
 @property(nonatomic, readonly, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
 - (NSInteger)setVoiceProcessingAGCEnabled:(BOOL)enabled;
 
+/// When enabled, the app is responsible for re-enabling Voice-Processing I/O after a mono-only
+/// route forces stereo playout off. Defaults to NO (auto-restore).
+@property(nonatomic, assign) BOOL manualRestoreVoiceProcessingOnMono;
+
 /// Indicates whether stereo playout can currently be enabled. Returns NO when only mono output is
 /// available (for example when Voice-Processing I/O is active or the route exposes a single
 /// channel).

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -179,11 +179,23 @@ RTC_OBJC_EXPORT
 
 /// Temporarily bypasses Voice-Processing I/O. Can be toggled at runtime without restarting the
 /// Audio Engine. Defaults to false.
-@property(nonatomic, assign, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
+@property(nonatomic, readonly, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
+- (NSInteger)setVoiceProcessingBypassed:(BOOL)enabled;
 
 /// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
 /// enabled. Enabled by default when VPIO is enabled.
-@property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
+@property(nonatomic, readonly, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
+- (NSInteger)setVoiceProcessingAGCEnabled:(BOOL)enabled;
+
+/// Indicates whether stereo playout can currently be enabled. Returns NO when only mono output is
+/// available (for example when Voice-Processing I/O is active or the route exposes a single
+/// channel).
+@property(nonatomic, readonly, getter=isStereoPlayoutAvailable) BOOL stereoPlayoutAvailable;
+
+/// Toggle stereo playout when available. If the underlying engine rejects the request (for example
+/// because the route only exposes a single channel), the property remains unchanged.
+@property(nonatomic, readonly, getter=isStereoPlayoutEnabled) BOOL stereoPlayoutEnabled;
+- (NSInteger)setStereoPlayoutEnabled:(BOOL)enabled;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -78,6 +78,10 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
       isStereoPlayoutAvailable:(BOOL)isStereoPlayoutAvailable
     NS_SWIFT_NAME(audioDeviceModule(_:isStereoPlayoutAvailable:));
 
+- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
+      isStereoPlayoutEnabled:(BOOL)isStereoPlayoutEnabled
+    NS_SWIFT_NAME(audioDeviceModule(_:isStereoPlayoutEnabled:));
+
 // Engine events
 - (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
                didCreateEngine:(AVAudioEngine *)engine

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -56,21 +56,9 @@ RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 (RTCAudioDeviceModuleDelegate)<NSObject>
 
-@required
-
     - (void)audioDeviceModule
     : (RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule didReceiveSpeechActivityEvent
     : (RTC_OBJC_TYPE(RTCSpeechActivityEvent))speechActivityEvent NS_SWIFT_NAME(audioDeviceModule(_:didReceiveSpeechActivityEvent:));
-
-// Stereo
-
-- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-      isStereoPlayoutAvailable:(BOOL)isStereoPlayoutAvailable
-    NS_SWIFT_NAME(audioDeviceModule(_:isStereoPlayoutAvailable:));
-
-- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-      isStereoPlayoutEnabled:(BOOL)isStereoPlayoutEnabled
-    NS_SWIFT_NAME(audioDeviceModule(_:isStereoPlayoutEnabled:));
 
 // Engine events
 - (NSInteger)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
@@ -123,11 +111,6 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 
 - (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
     NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
-
-@optional
-- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-    didUpdateStereoPlayoutAvailability:(BOOL)isAvailable
-    NS_SWIFT_NAME(audioDeviceModule(_:didUpdateStereoPlayoutAvailability:));
 
 @end
 
@@ -196,29 +179,11 @@ RTC_OBJC_EXPORT
 
 /// Temporarily bypasses Voice-Processing I/O. Can be toggled at runtime without restarting the
 /// Audio Engine. Defaults to false.
-@property(nonatomic, readonly, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
-- (NSInteger)setVoiceProcessingBypassed:(BOOL)enabled;
+@property(nonatomic, assign, getter=isVoiceProcessingBypassed) BOOL voiceProcessingBypassed;
 
 /// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
 /// enabled. Enabled by default when VPIO is enabled.
-@property(nonatomic, readonly, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
-- (NSInteger)setVoiceProcessingAGCEnabled:(BOOL)enabled;
-
-/// When enabled, the app is responsible for re-enabling Voice-Processing I/O after a mono-only
-/// route forces stereo playout off. Changing `AVAudioSession.mode` alone is not enough—call
-/// `setVoiceProcessingEnabled:YES` (and optionally `setVoiceProcessingBypassed:`) once you want to
-/// bring the VoiceProcessingIO path back. Defaults to NO (auto-restore).
-@property(nonatomic, assign) BOOL manualRestoreVoiceProcessingOnMono;
-
-/// Indicates whether stereo playout can currently be enabled. Returns NO when only mono output is
-/// available (for example when Voice-Processing I/O is active or the route exposes a single
-/// channel).
-@property(nonatomic, readonly, getter=isStereoPlayoutAvailable) BOOL stereoPlayoutAvailable;
-
-/// Toggle stereo playout when available. If the underlying engine rejects the request (for example
-/// because the route only exposes a single channel), the property remains unchanged.
-@property(nonatomic, readonly, getter=isStereoPlayoutEnabled) BOOL stereoPlayoutEnabled;
-- (NSInteger)setStereoPlayoutEnabled:(BOOL)enabled;
+@property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -143,6 +143,7 @@ RTC_OBJC_EXPORT
 - (BOOL)trySetOutputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 - (BOOL)trySetInputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 
+- (NSInteger)terminate;
 - (NSInteger)startPlayout;
 - (NSInteger)stopPlayout;
 - (NSInteger)initPlayout;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -143,7 +143,7 @@ RTC_OBJC_EXPORT
 - (BOOL)trySetOutputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 - (BOOL)trySetInputDevice:(nullable RTC_OBJC_TYPE(RTCIODevice) *)device;
 
-- (NSInteger)terminate;
+- (NSInteger)reset;
 - (NSInteger)startPlayout;
 - (NSInteger)stopPlayout;
 - (NSInteger)initPlayout;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -49,6 +49,13 @@ typedef struct {
   RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
 } RTC_OBJC_TYPE(RTCAudioEngineState);
 
+typedef struct { 
+  bool voiceProcessingEnabled; 
+  bool voiceProcessingBypassed; 
+  bool voiceProcessingAGCEnabled; 
+  bool stereoPlayoutEnabled; 
+} RTC_OBJC_TYPE(RTCAudioProcessingState);
+
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
 @class RTC_OBJC_TYPE(RTCAudioDeviceModule);
@@ -111,6 +118,10 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
 
 - (void)audioDeviceModuleDidUpdateDevices:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
     NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
+
+- (void)audioDeviceModule:(RTCAudioDeviceModule *)module
+    didUpdateAudioProcessingState:(RTCAudioProcessingState)state 
+    NS_SWIFT_NAME(audioDeviceModule(_:didUpdateAudioProcessingState:));
 
 @end
 
@@ -184,6 +195,14 @@ RTC_OBJC_EXPORT
 /// Indicates whether Automatic Gain Control (AGC) is enabled. Requires Voice-Processing I/O to be
 /// enabled. Enabled by default when VPIO is enabled.
 @property(nonatomic, assign, getter=isVoiceProcessingAGCEnabled) BOOL voiceProcessingAGCEnabled;
+
+/// Stereo Playout properties
+@property(nonatomic, readonly, assign, getter=isStereoPlayoutAvailable) BOOL stereoPlayoutAvailable;
+@property(nonatomic, readonly, assign, getter=isStereoPlayoutEnabled) BOOL stereoPlayoutEnabled;
+@property(nonatomic, assign) BOOL prefersStereoPlayout;
+@property(nonatomic, readonly, assign, getter=isManualRestoreVoiceProcessingOnMono) BOOL manualRestoreVoiceProcessingOnMono;
+- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)enabled;
+- (void)refreshStereoPlayoutState;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -49,16 +49,6 @@ typedef struct {
   RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
 } RTC_OBJC_TYPE(RTCAudioEngineState);
 
-typedef NS_ENUM(NSInteger, RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty)) {
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyMicrophoneMuted),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyRecordingAlwaysPreparedMode),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyManualRenderingMode),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingEnabled),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingBypassed),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyVoiceProcessingAGCEnabled),
-  RTC_OBJC_TYPE(RTCAudioDeviceModuleObservablePropertyStereoPlayoutEnabled)
-};
-
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
 @class RTC_OBJC_TYPE(RTCAudioDeviceModule);
@@ -135,11 +125,6 @@ RTC_OBJC_EXPORT @protocol RTC_OBJC_TYPE
     NS_SWIFT_NAME(audioDeviceModuleDidUpdateDevices(_:));
 
 @optional
-- (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
-    didChangeProperty:(RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty))property
-             newValue:(BOOL)newValue
-    NS_SWIFT_NAME(audioDeviceModule(_:didChangeProperty:newValue:));
-
 - (void)audioDeviceModule:(RTC_OBJC_TYPE(RTCAudioDeviceModule) *)audioDeviceModule
     didUpdateStereoPlayoutAvailability:(BOOL)isAvailable
     NS_SWIFT_NAME(audioDeviceModule(_:didUpdateStereoPlayoutAvailability:));

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -200,9 +200,9 @@ RTC_OBJC_EXPORT
 /// Stereo Playout properties
 @property(nonatomic, readonly, assign, getter=isStereoPlayoutAvailable) BOOL stereoPlayoutAvailable;
 @property(nonatomic, readonly, assign, getter=isStereoPlayoutEnabled) BOOL stereoPlayoutEnabled;
+// By setting this to true, Voice Processing will be disabled and won't be able to toggle while
+// this is true.
 @property(nonatomic, assign) BOOL prefersStereoPlayout;
-@property(nonatomic, readonly, assign, getter=isManualRestoreVoiceProcessingOnMono) BOOL manualRestoreVoiceProcessingOnMono;
-- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)enabled;
 - (void)refreshStereoPlayoutState;
 
 @end

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -52,6 +52,10 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
     [delegate_ audioDeviceModule:adm_ isStereoPlayoutAvailable:available ? YES : NO];
   }
 
+  void OnStereoUpdatedPlayoutEnabled(bool enabled) override {
+    [delegate_ audioDeviceModule:adm_ isStereoPlayoutEnabled:enabled ? YES : NO];
+  }
+
   int32_t OnEngineDidCreate(AVAudioEngine *engine) override {
     if (delegate_ == nil) return 0;
     return [delegate_ audioDeviceModule:adm_ didCreateEngine:engine];

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -48,6 +48,10 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
         didReceiveSpeechActivityEvent:ConvertSpeechActivityEvent(event)];
   }
 
+  void OnStereoUpdatedPlayoutAvailable(bool available) override {
+    [delegate_ audioDeviceModule:adm_ isStereoPlayoutAvailable:available ? YES : NO];
+  }
+
   int32_t OnEngineDidCreate(AVAudioEngine *engine) override {
     if (delegate_ == nil) return 0;
     return [delegate_ audioDeviceModule:adm_ didCreateEngine:engine];

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -589,6 +589,25 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   return result;
 }
 
+- (BOOL)manualRestoreVoiceProcessingOnMono {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    return module->ManualRestoreVoiceProcessingOnMono() ? YES : NO;
+  });
+}
+
+- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)manualRestore {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  const bool value = manualRestore == YES;
+  _workerThread->BlockingCall([module, value] {
+    module->SetManualRestoreVoiceProcessingOnMono(value);
+  });
+}
+
 - (BOOL)isStereoPlayoutAvailable {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -116,6 +116,16 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
                                 context:context];
   }
 
+  void OnAudioProcessingStateChanged(const webrtc::AudioProcessingState& state) override {
+    if (delegate_ == nil) return;
+    RTCAudioProcessingState objcState;
+    objcState.voiceProcessingEnabled = state.voice_processing_enabled ? YES : NO;
+    objcState.voiceProcessingBypassed = state.voice_processing_bypassed ? YES : NO;
+    objcState.voiceProcessingAGCEnabled = state.voice_processing_agc_enabled ? YES : NO;
+    objcState.stereoPlayoutEnabled = state.stereo_playout_enabled ? YES : NO;
+    [delegate_ audioDeviceModule:adm_ didUpdateAudioProcessingState:objcState];
+  }
+
   __weak id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate_;
 
  private:
@@ -523,6 +533,61 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
   _workerThread->BlockingCall(
       [module, enabled] { return module->SetVoiceProcessingAGCEnabled(enabled) == 0; });
+}
+
+- (BOOL)isStereoPlayoutAvailable {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->StereoPlayoutIsAvailable(&value) == 0 ? value : NO;
+  });
+}
+
+- (BOOL)isStereoPlayoutEnabled {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    bool value = false;
+    return module->StereoPlayout(&value) == 0 ? value : NO;
+  });
+}
+
+- (BOOL)prefersStereoPlayout {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return NO;
+
+  return _workerThread->BlockingCall([module] {
+    webrtc::AudioEngineDevice::EngineState state;
+    if (module->GetEngineState(&state) != 0) {
+      return false;
+    }
+    return state.prefers_stereo_playout;
+  });
+}
+
+- (void)setPrefersStereoPlayout:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall([module, enabled] { module->SetStereoPlayout(enabled); });
+}
+
+- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)enabled {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall(
+      [module, enabled] { module->SetManualRestoreVoiceProcessingOnMono(enabled); });
+}
+
+- (void)refreshStereoPlayoutState {
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return;
+
+  _workerThread->BlockingCall([module] { module->RefreshStereoPlayoutState(); });
 }
 
 #pragma mark - Private

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -282,8 +282,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
 #pragma mark - Low-level access
 
-- (NSInteger)terminate {
-  return _workerThread->BlockingCall([self] { return _native->Terminate(); });
+- (NSInteger)reset {
+  return _workerThread->BlockingCall([self] { return _native->Reset(); });
 }
 
 - (NSInteger)startPlayout {

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -282,6 +282,10 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
 #pragma mark - Low-level access
 
+- (NSInteger)terminate {
+  return _workerThread->BlockingCall([self] { return _native->Terminate(); });
+}
+
 - (NSInteger)startPlayout {
   return _workerThread->BlockingCall([self] { return _native->StartPlayout(); });
 }

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -579,14 +579,6 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   _workerThread->BlockingCall([module, enabled] { module->SetStereoPlayout(enabled); });
 }
 
-- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return;
-
-  _workerThread->BlockingCall(
-      [module, enabled] { module->SetManualRestoreVoiceProcessingOnMono(enabled); });
-}
-
 - (void)refreshStereoPlayoutState {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -348,18 +348,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setMicrophoneMuted:(BOOL)muted {
-  BOOL shouldNotify = self.isMicrophoneMuted != muted;
-
-  NSInteger result =
-      _workerThread->BlockingCall([self, muted] { return _native->SetMicrophoneMute(muted); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyMicrophoneMuted)
-                           newValue:muted];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([self, muted] { 
+    return _native->SetMicrophoneMute(muted); 
+  });
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
@@ -417,18 +408,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isRecordingAlwaysPreparedMode != enabled;
-
-  NSInteger result = _workerThread->BlockingCall(
-      [module, enabled] { return module->SetInitRecordingPersistentMode(enabled); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyRecordingAlwaysPreparedMode)
-                           newValue:enabled];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([module, enabled] { 
+    return module->SetInitRecordingPersistentMode(enabled); 
+  });
 }
 
 - (BOOL)isManualRenderingMode {
@@ -445,18 +427,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isManualRenderingMode != enabled;
-
-  NSInteger result =
-      _workerThread->BlockingCall([module, enabled] { return module->SetManualRenderingMode(enabled); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyManualRenderingMode)
-                           newValue:enabled];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([module, enabled] { 
+    return module->SetManualRenderingMode(enabled); 
+  });
 }
 
 - (BOOL)isAdvancedDuckingEnabled {
@@ -527,18 +500,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isVoiceProcessingEnabled != enabled;
-
-  NSInteger result = _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingEnabled(enabled); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyVoiceProcessingEnabled)
-                           newValue:enabled];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([module, enabled] { 
+    return module->SetVoiceProcessingEnabled(enabled); 
+  });
 }
 
 - (BOOL)isVoiceProcessingBypassed {
@@ -555,18 +519,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isVoiceProcessingBypassed != enabled;
-
-  NSInteger result = _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingBypassed(enabled); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyVoiceProcessingBypassed)
-                           newValue:enabled];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([module, enabled] { 
+    return module->SetVoiceProcessingBypassed(enabled); 
+  });
 }
 
 - (BOOL)isVoiceProcessingAGCEnabled {
@@ -583,18 +538,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isVoiceProcessingAGCEnabled != enabled;
-
-  NSInteger result = _workerThread->BlockingCall(
-      [module, enabled] { return module->SetVoiceProcessingAGCEnabled(enabled); });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyVoiceProcessingAGCEnabled)
-                           newValue:enabled];
-  }
-
-  return result;
+  return _workerThread->BlockingCall([module, enabled] { 
+    return module->SetVoiceProcessingAGCEnabled(enabled); 
+  });
 }
 
 - (BOOL)manualRestoreVoiceProcessingOnMono {
@@ -640,9 +586,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  BOOL shouldNotify = self.isStereoPlayoutEnabled != enabled;
-
-  NSInteger result = _workerThread->BlockingCall([module, enabled] {
+  return _workerThread->BlockingCall([module, enabled] {
     const bool stereo_enabled = enabled == YES;
     int32_t result = module->SetStereoPlayout(stereo_enabled);
     if (result != 0) {
@@ -650,30 +594,6 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
     }
     return result;
   });
-
-  if (shouldNotify && result == 0) {
-    [self _notifyObserverForProperty:RTC_OBJC_TYPE(
-                                       RTCAudioDeviceModuleObservablePropertyStereoPlayoutEnabled)
-                           newValue:enabled];
-  }
-
-  return result;
-}
-
-#pragma mark - Observer notifications
-
-- (void)_notifyObserverForProperty:
-            (RTC_OBJC_TYPE(RTCAudioDeviceModuleObservableProperty))property
-                          newValue:(BOOL)newValue {
-  id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)> delegate = self.observer;
-  if (delegate == nil) {
-    return;
-  }
-
-  SEL selector = @selector(audioDeviceModule:didChangeProperty:newValue:);
-  if ([delegate respondsToSelector:selector]) {
-    [delegate audioDeviceModule:self didChangeProperty:property newValue:newValue];
-  }
 }
 
 #pragma mark - Private

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -48,14 +48,6 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
         didReceiveSpeechActivityEvent:ConvertSpeechActivityEvent(event)];
   }
 
-  void OnStereoUpdatedPlayoutAvailable(bool available) override {
-    [delegate_ audioDeviceModule:adm_ isStereoPlayoutAvailable:available ? YES : NO];
-  }
-
-  void OnStereoUpdatedPlayoutEnabled(bool enabled) override {
-    [delegate_ audioDeviceModule:adm_ isStereoPlayoutEnabled:enabled ? YES : NO];
-  }
-
   int32_t OnEngineDidCreate(AVAudioEngine *engine) override {
     if (delegate_ == nil) return 0;
     return [delegate_ audioDeviceModule:adm_ didCreateEngine:engine];
@@ -348,9 +340,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setMicrophoneMuted:(BOOL)muted {
-  return _workerThread->BlockingCall([self, muted] { 
-    return _native->SetMicrophoneMute(muted); 
-  });
+  return _workerThread->BlockingCall([self, muted] { return _native->SetMicrophoneMute(muted); });
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
@@ -378,9 +368,6 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
   _workerThread->BlockingCall([module, state] {
     webrtc::AudioEngineDevice::EngineState result;
-    if (module->GetEngineState(&result) != 0) {
-      result = webrtc::AudioEngineDevice::EngineState();
-    }
     result.output_enabled = state.outputEnabled;
     result.output_running = state.outputRunning;
     result.input_enabled = state.inputEnabled;
@@ -408,9 +395,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  return _workerThread->BlockingCall([module, enabled] { 
-    return module->SetInitRecordingPersistentMode(enabled); 
-  });
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetInitRecordingPersistentMode(enabled); });
 }
 
 - (BOOL)isManualRenderingMode {
@@ -427,9 +413,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  return _workerThread->BlockingCall([module, enabled] { 
-    return module->SetManualRenderingMode(enabled); 
-  });
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetManualRenderingMode(enabled); });
 }
 
 - (BOOL)isAdvancedDuckingEnabled {
@@ -500,9 +485,8 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
-  return _workerThread->BlockingCall([module, enabled] { 
-    return module->SetVoiceProcessingEnabled(enabled); 
-  });
+  return _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingEnabled(enabled); });
 }
 
 - (BOOL)isVoiceProcessingBypassed {
@@ -515,13 +499,12 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   });
 }
 
-- (NSInteger)setVoiceProcessingBypassed:(BOOL)enabled {
+- (void)setVoiceProcessingBypassed:(BOOL)enabled {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
+  if (module == nullptr) return;
 
-  return _workerThread->BlockingCall([module, enabled] { 
-    return module->SetVoiceProcessingBypassed(enabled); 
-  });
+  _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingBypassed(enabled) == 0; });
 }
 
 - (BOOL)isVoiceProcessingAGCEnabled {
@@ -534,66 +517,12 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   });
 }
 
-- (NSInteger)setVoiceProcessingAGCEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
-
-  return _workerThread->BlockingCall([module, enabled] { 
-    return module->SetVoiceProcessingAGCEnabled(enabled); 
-  });
-}
-
-- (BOOL)manualRestoreVoiceProcessingOnMono {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    return module->ManualRestoreVoiceProcessingOnMono() ? YES : NO;
-  });
-}
-
-- (void)setManualRestoreVoiceProcessingOnMono:(BOOL)manualRestore {
+- (void)setVoiceProcessingAGCEnabled:(BOOL)enabled {
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
-  const bool value = manualRestore == YES;
-  _workerThread->BlockingCall([module, value] {
-    module->SetManualRestoreVoiceProcessingOnMono(value);
-  });
-}
-
-- (BOOL)isStereoPlayoutAvailable {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool available = false;
-    return module->StereoPlayoutIsAvailable(&available) == 0 ? (available ? YES : NO) : NO;
-  });
-}
-
-- (BOOL)isStereoPlayoutEnabled {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return NO;
-
-  return _workerThread->BlockingCall([module] {
-    bool enabled = false;
-    return module->StereoPlayout(&enabled) == 0 ? (enabled ? YES : NO) : NO;
-  });
-}
-
-- (NSInteger)setStereoPlayoutEnabled:(BOOL)enabled {
-  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return -1;
-
-  return _workerThread->BlockingCall([module, enabled] {
-    const bool stereo_enabled = enabled == YES;
-    int32_t result = module->SetStereoPlayout(stereo_enabled);
-    if (result != 0) {
-      RTCLogError(@"Failed to set stereo playout (%d)", result);
-    }
-    return result;
-  });
+  _workerThread->BlockingCall(
+      [module, enabled] { return module->SetVoiceProcessingAGCEnabled(enabled) == 0; });
 }
 
 #pragma mark - Private


### PR DESCRIPTION
### Summary

Stereo playout is now an explicit opt-in on the iOS AVAudioEngine ADM. The module tracks stereo availability per audio route, exposes it through the Objective-C surface area, and keeps voice-processing features in sync so integrators can decide when to toggle between mono and stereo.

- Extend AudioEngineDevice to track stereo preference, availability, and enablement, add Reset(), refresh on route changes, and improve debug logging.
- Rework channel negotiation so the engine respects hardware capabilities, reconciles manual/device rendering, and keeps voice processing coherent when stereo is active.
- Update the Objective-C wrapper with prefersStereoPlayout, stereoPlayoutAvailable, stereoPlayoutEnabled, reset, refreshStereoPlayoutState, and a new delegate callback to surface processing state changes.
- Stop forcing stereo automatically from higher-level call sites; availability is logged and left to the application to opt in.


### Integrator Guide

1. Adopt audioDeviceModule(_:didUpdateAudioProcessingState:) to observe stereo/voice-processing changes.
2. Check audioDeviceModule.stereoPlayoutAvailable when the audio route changes; call refreshStereoPlayoutState() after custom route handling to recompute availability without rebuilding the engine.
3. Enable stereo via audioDeviceModule.prefersStereoPlayout = true. The ADM will disable voice processing/AGC while stereo is requested; set it back to false to return to mono.
4. Use audioDeviceModule.stereoPlayoutEnabled to confirm the engine actually switched, and guard against routes that only expose a single channel.
5. Call audioDeviceModule.reset() if you need to tear down and rebuild the ADM (for example, after long-running sessions with custom graph changes).

### Swift Example

```swift
final class CallAudioController: NSObject, RTCAudioDeviceModuleDelegate {
  private let audioModule: RTCAudioDeviceModule

  init?(factory: RTCPeerConnectionFactory) {
    guard let module = factory.audioDeviceModule() else { return nil }
    audioModule = module
    super.init()
    audioModule.delegate = self
  }

  func updateRoutePreference() {
    if audioModule.stereoPlayoutAvailable {
      audioModule.prefersStereoPlayout = true
    }
    audioModule.refreshStereoPlayoutState()
  }

  func audioDeviceModule(_ module: RTCAudioDeviceModule,
                         didUpdateAudioProcessingState state: RTCAudioProcessingState) {
    guard state.stereoPlayoutEnabled else { return }
    // Update UI, notify analytics, etc.
  }
}
```