### PR TITLE
[Fix]Simulator h240/h265 missing frames

### DIFF
--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -763,6 +763,31 @@ NSUInteger GetMaxSampleRate(
       compressionOutputCallback,
       nullptr,
       &_compressionSession);
+  if (status == kVTCouldNotFindVideoEncoderErr) {
+    if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
+      NSMutableDictionary *fallback_specs = [encoder_specs mutableCopy];
+      [fallback_specs removeObjectForKey:(NSString *)
+                                     kVTVideoEncoderSpecification_EnableLowLatencyRateControl];
+      if (fallback_specs.count != encoder_specs.count) {
+        RTC_LOG(LS_WARNING) << "VTCompressionSessionCreate failed with "
+                            << status
+                            << ", retrying without low-latency rate control.";
+        CFDictionaryRef fallback_spec_ref =
+            fallback_specs.count > 0 ? (__bridge CFDictionaryRef)fallback_specs : nullptr;
+        status = VTCompressionSessionCreate(
+            nullptr,  // use default allocator
+            _width,
+            _height,
+            kCMVideoCodecType_H264,
+            fallback_spec_ref,
+            (__bridge CFDictionaryRef)sourceAttributes,
+            nullptr,  // use default compressed data allocator
+            compressionOutputCallback,
+            nullptr,
+            &_compressionSession);
+      }
+    }
+  }
   if (status != noErr) {
     RTC_LOG(LS_ERROR) << "Failed to create compression session: " << status;
     return WEBRTC_VIDEO_CODEC_ERROR;
@@ -977,4 +1002,3 @@ NSUInteger GetMaxSampleRate(
 }
 
 @end
-

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -744,7 +744,11 @@ NSUInteger GetMaxSampleRate(
     }];
   }
 
-  // Enable low-latency video encoding
+  // Enable low-latency video encoding.
+  // NOTE: Some VideoToolbox configurations (notably simulator combos) report
+  // kVTCouldNotFindVideoEncoderErr when this key is present, even though the
+  // default encoder is available. We add the key optimistically, then fall back
+  // to a retry without it if VT cannot find an encoder.
   if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
     [encoder_specs addEntriesFromDictionary:@{
       (NSString *)kVTVideoEncoderSpecification_EnableLowLatencyRateControl : @(YES),
@@ -763,6 +767,8 @@ NSUInteger GetMaxSampleRate(
       compressionOutputCallback,
       nullptr,
       &_compressionSession);
+  // Retry once without the low-latency spec if that exact error is returned.
+  // We only do this when the key was present, to avoid redundant retries.
   if (status == kVTCouldNotFindVideoEncoderErr) {
     if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
       NSMutableDictionary *fallback_specs = [encoder_specs mutableCopy];

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
@@ -404,6 +404,33 @@ void compressionOutputCallback(void* encoder, void* params, OSStatus status,
                                  sourceAttributes,
                                  nullptr,  // use default compressed data allocator
                                  compressionOutputCallback, nullptr, &_compressionSession);
+  if (status == kVTCouldNotFindVideoEncoderErr) {
+    if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
+      if (CFDictionaryGetCount(encoder_specs) > 0) {
+        CFMutableDictionaryRef fallback_specs = CFDictionaryCreateMutableCopy(
+            nullptr, 0, encoder_specs);
+        if (fallback_specs) {
+          CFDictionaryRemoveValue(
+              fallback_specs, kVTVideoEncoderSpecification_EnableLowLatencyRateControl);
+          if (CFDictionaryGetCount(fallback_specs) != CFDictionaryGetCount(encoder_specs)) {
+            RTC_LOG(LS_WARNING) << "VTCompressionSessionCreate failed with "
+                                << status
+                                << ", retrying without low-latency rate control.";
+            CFDictionaryRef fallback_spec_ref =
+                CFDictionaryGetCount(fallback_specs) > 0 ? fallback_specs : nullptr;
+            status = VTCompressionSessionCreate(
+                nullptr,  // use default allocator
+                _width, _height, kCMVideoCodecType_HEVC,
+                fallback_spec_ref,
+                sourceAttributes,
+                nullptr,  // use default compressed data allocator
+                compressionOutputCallback, nullptr, &_compressionSession);
+          }
+          CFRelease(fallback_specs);
+        }
+      }
+    }
+  }
   if (status != noErr) {
     status =
         VTCompressionSessionCreate(nullptr,  // use default allocator

--- a/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
+++ b/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm
@@ -392,6 +392,11 @@ void compressionOutputCallback(void* encoder, void* params, OSStatus status,
                          kCFBooleanTrue);
   }
 
+  // Enable low-latency rate control where available.
+  // NOTE: Some VideoToolbox environments (especially simulator) can fail to
+  // locate an encoder when this flag is present, even though a default encoder
+  // exists. We handle that by retrying without the flag when we see
+  // kVTCouldNotFindVideoEncoderErr below.
   if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
     CFDictionarySetValue(encoder_specs, kVTVideoEncoderSpecification_EnableLowLatencyRateControl,
                          kCFBooleanTrue);
@@ -404,6 +409,8 @@ void compressionOutputCallback(void* encoder, void* params, OSStatus status,
                                  sourceAttributes,
                                  nullptr,  // use default compressed data allocator
                                  compressionOutputCallback, nullptr, &_compressionSession);
+  // Retry once without low-latency if VT can't find an encoder with it enabled.
+  // Guard on dictionary contents to avoid unnecessary work.
   if (status == kVTCouldNotFindVideoEncoderErr) {
     if (@available(iOS 14.5, macCatalyst 14.5, macOS 11.3, tvOS 14.5, visionOS 1.0, *)) {
       if (CFDictionaryGetCount(encoder_specs) > 0) {


### PR DESCRIPTION
## Summary

If VTCompressionSessionCreate fails with kVTCouldNotFindVideoEncoderErr, retry without kVTVideoEncoderSpecification_EnableLowLatencyRateControl. This restores H264/H265 encoding (notably on simulator) after the 137 bump.

## Problem

After updating WebRTC to 137.x, simulator builds render locally but remote participants/SFU receive no video.
Logs show H.264 encoder init fails: VTCompressionSessionCreate returns -12908 (kVTCouldNotFindVideoEncoderErr).
Result: VideoSendStream stats has encode_fps = 0 / media_bps = 0.

## Root cause

In 137, RTCVideoEncoderH264 and RTCVideoEncoderH265 always include kVTVideoEncoderSpecification_EnableLowLatencyRateControl (iOS 14.5+).
On simulator, this spec can make VideoToolbox fail to find an encoder.
Fix

If VTCompressionSessionCreate fails with kVTCouldNotFindVideoEncoderErr, retry without the low‑latency rate control spec.
Guarded with [available(iOS 14.5, ...)](app://-/index.html#) to avoid deployment target warnings.

## How verified

Rebuilt WebRTC and ran simulator call; encoder initializes and remote video is received.
Expected log improvement: no Failed to create compression session: -12908, VideoSendStream stats shows non‑zero encode_fps / media_bps.

## Notes

No behavior change on devices; fallback only triggers on the specific error code.