### PR TITLE
[Enhancement] Add iOS PiP renderer and frame conversion pipeline

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -594,6 +594,10 @@ if (is_ios || is_mac) {
         "objc/api/video_frame_buffer/RTCNativeI420Buffer.mm",
         "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.h",
         "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.mm",
+        "objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.h",
+        "objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.m",
+        "objc/components/renderer/pip/RTCVideoFrameConverter.h",
+        "objc/components/renderer/pip/RTCVideoFrameConverter.mm",
         "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
         "objc/components/video_frame_buffer/RTCCVPixelBuffer.mm",
       ]
@@ -621,7 +625,9 @@ if (is_ios || is_mac) {
         ":used_from_extension",
       ]
       frameworks = [
+        "AVFoundation.framework",
         "VideoToolbox.framework",
+        "CoreMedia.framework",
         "CoreGraphics.framework",
         "CoreVideo.framework",
       ]
@@ -1602,6 +1608,8 @@ if (is_ios || is_mac) {
             "objc/helpers/RTCCameraPreviewView.h",
             "objc/components/renderer/metal/RTCMTLVideoView.h",
             "objc/components/renderer/metal/RTCVideoRenderingView.h",
+            "objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.h",
+            "objc/components/renderer/pip/RTCVideoFrameConverter.h",
           ]
         }
 

--- a/sdk/objc/api/video_frame_buffer/RTCNativeI420Buffer.mm
+++ b/sdk/objc/api/video_frame_buffer/RTCNativeI420Buffer.mm
@@ -11,13 +11,16 @@
 #import "RTCNativeI420Buffer+Private.h"
 
 #include "api/video/i420_buffer.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
 
 #if !defined(NDEBUG) && defined(WEBRTC_IOS)
 #import <UIKit/UIKit.h>
 #include "third_party/libyuv/include/libyuv.h"
 #endif
 
-@implementation RTC_OBJC_TYPE (RTCI420Buffer)
+@implementation RTC_OBJC_TYPE (RTCI420Buffer) {
+  CVPixelBufferRef _pixelBuffer;
+}
 
 - (instancetype)initWithWidth:(int)width height:(int)height {
   self = [super init];
@@ -68,6 +71,13 @@
   return self;
 }
 
+- (void)dealloc {
+  if (_pixelBuffer) {
+    CVBufferRelease(_pixelBuffer);
+    _pixelBuffer = nil;
+  }
+}
+
 - (int)width {
   return _i420Buffer->width();
 }
@@ -108,12 +118,85 @@
   return _i420Buffer->DataV();
 }
 
+- (CVPixelBufferRef)pixelBuffer {
+  // Cache conversion result because PiP/converter may request pixel buffer
+  // repeatedly for consecutive frames with same backing buffer instance.
+  if (_pixelBuffer || !_i420Buffer) {
+    return _pixelBuffer;
+  }
+
+  const int width = _i420Buffer->width();
+  const int height = _i420Buffer->height();
+  if (width <= 0 || height <= 0) {
+    return nil;
+  }
+
+  NSDictionary *attributes =
+      @{(id)kCVPixelBufferIOSurfacePropertiesKey : @{}};
+  // Export as NV12 because this is the common hardware-friendly format used by
+  // AVFoundation rendering pipelines.
+  CVReturn result = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+      (__bridge CFDictionaryRef)attributes,
+      &_pixelBuffer);
+  if (result != kCVReturnSuccess || !_pixelBuffer) {
+    return nil;
+  }
+
+  CVPixelBufferLockBaseAddress(_pixelBuffer, 0);
+  uint8_t *dst_y = static_cast<uint8_t *>(
+      CVPixelBufferGetBaseAddressOfPlane(_pixelBuffer, 0));
+  uint8_t *dst_uv = static_cast<uint8_t *>(
+      CVPixelBufferGetBaseAddressOfPlane(_pixelBuffer, 1));
+  if (!dst_y || !dst_uv) {
+    CVPixelBufferUnlockBaseAddress(_pixelBuffer, 0);
+    CVBufferRelease(_pixelBuffer);
+    _pixelBuffer = nil;
+    return nil;
+  }
+
+  const int dst_stride_y =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(_pixelBuffer, 0));
+  const int dst_stride_uv =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(_pixelBuffer, 1));
+
+  // Convert I420 planes to NV12 plane layout into the destination pixel buffer.
+  const int conversion_result = libyuv::I420ToNV12(
+      _i420Buffer->DataY(),
+      _i420Buffer->StrideY(),
+      _i420Buffer->DataU(),
+      _i420Buffer->StrideU(),
+      _i420Buffer->DataV(),
+      _i420Buffer->StrideV(),
+      dst_y,
+      dst_stride_y,
+      dst_uv,
+      dst_stride_uv,
+      width,
+      height);
+
+  CVPixelBufferUnlockBaseAddress(_pixelBuffer, 0);
+
+  if (conversion_result != 0) {
+    CVBufferRelease(_pixelBuffer);
+    _pixelBuffer = nil;
+    return nil;
+  }
+
+  return _pixelBuffer;
+}
+
 - (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)cropAndScaleWith:(int)offsetX
                                                    offsetY:(int)offsetY
                                                  cropWidth:(int)cropWidth
-                                                cropHeight:(int)cropHeight
-                                                scaleWidth:(int)scaleWidth
+                                                 cropHeight:(int)cropHeight
+                                                 scaleWidth:(int)scaleWidth
                                                scaleHeight:(int)scaleHeight {
+  // Keep behavior aligned with WebRTC frame buffer contract:
+  // crop/scale returns another frame buffer representation of same family.
   webrtc::scoped_refptr<webrtc::VideoFrameBuffer> scaled_buffer =
       _i420Buffer->CropAndScale(
           offsetX, offsetY, cropWidth, cropHeight, scaleWidth, scaleHeight);

--- a/sdk/objc/api/video_frame_buffer/RTCNativeNV12Buffer.mm
+++ b/sdk/objc/api/video_frame_buffer/RTCNativeNV12Buffer.mm
@@ -11,9 +11,14 @@
 #import "RTCNativeNV12Buffer+Private.h"
 #import "RTCNativeI420Buffer+Private.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include "api/video/nv12_buffer.h"
 
-@implementation RTC_OBJC_TYPE(RTCNV12Buffer)
+@implementation RTC_OBJC_TYPE(RTCNV12Buffer) {
+  CVPixelBufferRef _pixelBuffer;
+}
 
 - (instancetype)initWithWidth:(int)width height:(int)height {
   self = [super init];
@@ -42,6 +47,13 @@
     _nv12Buffer = nv12Buffer;
   }
   return self;
+}
+
+- (void)dealloc {
+  if (_pixelBuffer) {
+    CVBufferRelease(_pixelBuffer);
+    _pixelBuffer = nil;
+  }
 }
 
 - (int)width {
@@ -74,6 +86,127 @@
 
 - (const uint8_t *)dataUV {
   return _nv12Buffer->DataUV();
+}
+
+- (CVPixelBufferRef)pixelBuffer {
+  // Cache generated pixel buffer to avoid repeated plane copies for same frame
+  // buffer instance.
+  if (_pixelBuffer || !_nv12Buffer) {
+    return _pixelBuffer;
+  }
+
+  const int width = _nv12Buffer->width();
+  const int height = _nv12Buffer->height();
+  if (width <= 0 || height <= 0) {
+    return nil;
+  }
+
+  NSDictionary *attributes =
+      @{(id)kCVPixelBufferIOSurfacePropertiesKey : @{}};
+  // Preserve NV12 format end-to-end to avoid unnecessary color space/layout
+  // transformations.
+  CVReturn result = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+      (__bridge CFDictionaryRef)attributes,
+      &_pixelBuffer);
+  if (result != kCVReturnSuccess || !_pixelBuffer) {
+    return nil;
+  }
+
+  CVPixelBufferLockBaseAddress(_pixelBuffer, 0);
+
+  uint8_t *dst_y = static_cast<uint8_t *>(
+      CVPixelBufferGetBaseAddressOfPlane(_pixelBuffer, 0));
+  uint8_t *dst_uv = static_cast<uint8_t *>(
+      CVPixelBufferGetBaseAddressOfPlane(_pixelBuffer, 1));
+  if (!dst_y || !dst_uv) {
+    CVPixelBufferUnlockBaseAddress(_pixelBuffer, 0);
+    CVBufferRelease(_pixelBuffer);
+    _pixelBuffer = nil;
+    return nil;
+  }
+
+  // Copy Y and UV planes row-by-row to honor source/destination stride
+  // differences.
+  const int dst_stride_y =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(_pixelBuffer, 0));
+  const int dst_stride_uv =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(_pixelBuffer, 1));
+  const int src_stride_y = _nv12Buffer->StrideY();
+  const int src_stride_uv = _nv12Buffer->StrideUV();
+  const int y_row_bytes = std::min(width, std::min(src_stride_y, dst_stride_y));
+  const int uv_row_bytes = std::min(width + width % 2,
+                                    std::min(src_stride_uv, dst_stride_uv));
+
+  const uint8_t *src_y = _nv12Buffer->DataY();
+  const uint8_t *src_uv = _nv12Buffer->DataUV();
+
+  for (int row = 0; row < height; ++row) {
+    memcpy(dst_y + row * dst_stride_y, src_y + row * src_stride_y, y_row_bytes);
+  }
+
+  const int uv_rows = (height + 1) / 2;
+  for (int row = 0; row < uv_rows; ++row) {
+    memcpy(dst_uv + row * dst_stride_uv,
+           src_uv + row * src_stride_uv,
+           uv_row_bytes);
+  }
+
+  CVPixelBufferUnlockBaseAddress(_pixelBuffer, 0);
+  return _pixelBuffer;
+}
+
+- (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)cropAndScaleWith:(int)offsetX
+                                                   offsetY:(int)offsetY
+                                                 cropWidth:(int)cropWidth
+                                                 cropHeight:(int)cropHeight
+                                                 scaleWidth:(int)scaleWidth
+                                               scaleHeight:(int)scaleHeight {
+  // Validate early so callers can use this API in hot render paths without
+  // worrying about throwing/assert behavior.
+  if (!_nv12Buffer || scaleWidth <= 0 || scaleHeight <= 0 || cropWidth <= 0 ||
+      cropHeight <= 0) {
+    return nil;
+  }
+
+  const int source_width = _nv12Buffer->width();
+  const int source_height = _nv12Buffer->height();
+  if (source_width <= 0 || source_height <= 0) {
+    return nil;
+  }
+
+  // NV12 chroma is 2x2 subsampled; align crop offsets to even boundaries.
+  const int max_offset_x = std::max(0, source_width - 1);
+  const int max_offset_y = std::max(0, source_height - 1);
+  const int adjusted_offset_x = std::max(0, std::min(offsetX, max_offset_x)) & ~1;
+  const int adjusted_offset_y = std::max(0, std::min(offsetY, max_offset_y)) & ~1;
+
+  const int max_crop_width = source_width - adjusted_offset_x;
+  const int max_crop_height = source_height - adjusted_offset_y;
+  const int adjusted_crop_width = std::max(1, std::min(cropWidth, max_crop_width));
+  const int adjusted_crop_height =
+      std::max(1, std::min(cropHeight, max_crop_height));
+
+  webrtc::scoped_refptr<webrtc::NV12Buffer> scaled_buffer =
+      webrtc::NV12Buffer::Create(scaleWidth, scaleHeight);
+  if (!scaled_buffer) {
+    return nil;
+  }
+
+  // Reuse WebRTC's native NV12 crop/scale implementation for consistency with
+  // other renderers and codec paths.
+  scaled_buffer->CropAndScaleFrom(*_nv12Buffer,
+                                  adjusted_offset_x,
+                                  adjusted_offset_y,
+                                  adjusted_crop_width,
+                                  adjusted_crop_height);
+
+  RTC_OBJC_TYPE(RTCNV12Buffer) *result =
+      [[RTC_OBJC_TYPE(RTCNV12Buffer) alloc] initWithFrameBuffer:scaled_buffer];
+  return result;
 }
 
 - (id<RTC_OBJC_TYPE(RTCI420Buffer)>)toI420 {

--- a/sdk/objc/base/RTCVideoFrameBuffer.h
+++ b/sdk/objc/base/RTCVideoFrameBuffer.h
@@ -28,6 +28,9 @@ RTC_OBJC_EXPORT
 - (id<RTC_OBJC_TYPE(RTCI420Buffer)>)toI420;
 
 @optional
+// Optional CVPixelBuffer representation of this frame buffer.
+// Implementations may return nil if conversion/export is unavailable.
+@property(nonatomic, readonly, nullable) CVPixelBufferRef pixelBuffer;
 - (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)cropAndScaleWith:(int)offsetX
                                                    offsetY:(int)offsetY
                                                  cropWidth:(int)cropWidth

--- a/sdk/objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.h
+++ b/sdk/objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <AVFoundation/AVFoundation.h>
+
+#import "RTCVideoRenderer.h"
+#import "sdk/objc/base/RTCMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+/**
+ * Ready-to-use PiP renderer for WebRTC tracks.
+ *
+ * This view conforms to `RTCVideoRenderer` and can be attached directly to
+ * `RTCVideoTrack`. Internally, it:
+ * - converts incoming `RTCVideoFrame` to `CMSampleBuffer` using
+ *   `RTCVideoFrameConverter`,
+ * - enqueues frames into an `AVSampleBufferDisplayLayer`,
+ * - stays agnostic to WebRTC frame policies/backends.
+ */
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer)
+    : UIView<RTC_OBJC_TYPE(RTCVideoRenderer)>
+
+/** Mirrors existing WebRTC renderer delegate semantics. */
+@property(nonatomic, weak) id<RTC_OBJC_TYPE(RTCVideoViewDelegate)> delegate;
+/** Turns rendering on/off without detaching the renderer from track. */
+@property(nonatomic, getter=isEnabled) BOOL enabled;
+/** Forwards directly to underlying AVSampleBufferDisplayLayer gravity. */
+@property(nonatomic) AVLayerVideoGravity videoGravity;
+/**
+ * If enabled, incoming frames are resized to renderer bounds before enqueue.
+ * If disabled, renderer uses track-reported size/frame size.
+ */
+@property(nonatomic) BOOL resizesFramesToRendererSize;
+
+@end
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/sdk/objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.m
+++ b/sdk/objc/components/renderer/pip/RTCPictureInPictureVideoRenderer.m
@@ -1,0 +1,219 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import "RTCPictureInPictureVideoRenderer.h"
+
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+
+#import "RTCVideoFrameConverter.h"
+#import "base/RTCVideoFrame.h"
+
+@interface RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer) ()
+
+// Shared converter instance reused across frames.
+// This enables internal pool reuse in converter and keeps per-frame overhead low.
+@property(nonatomic, strong) RTC_OBJC_TYPE(RTCVideoFrameConverter) *frameConverter;
+// Serial queue ensures frame conversion is ordered and non-concurrent.
+// This protects converter internal state and avoids frame reordering.
+@property(nonatomic, strong) dispatch_queue_t renderQueue;
+// Last size reported by WebRTC through `setSize:`.
+@property(nonatomic, assign) CGSize videoSize;
+// Cached renderer bounds size, updated in `layoutSubviews`.
+@property(nonatomic, assign) CGSize rendererSize;
+
+@end
+
+@implementation RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer)
+
+@synthesize delegate = _delegate;
+
++ (Class)layerClass {
+  // PiP display path is sample-buffer based, so use AVSampleBufferDisplayLayer.
+  return AVSampleBufferDisplayLayer.class;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  if (self) {
+    [self configure];
+  }
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super initWithCoder:coder];
+  if (self) {
+    [self configure];
+  }
+  return self;
+}
+
+- (void)configure {
+  // Default behavior mirrors WebRTC renderers:
+  // - renderer active by default
+  // - aspect-fill display
+  // - resize frames to current view bounds for PiP stability
+  _enabled = YES;
+  _resizesFramesToRendererSize = YES;
+  _frameConverter = [[RTC_OBJC_TYPE(RTCVideoFrameConverter) alloc] init];
+  _renderQueue =
+      dispatch_queue_create("org.webrtc.pip-video-renderer",
+                            DISPATCH_QUEUE_SERIAL);
+  _rendererSize = self.bounds.size;
+  
+  self.videoGravity = AVLayerVideoGravityResizeAspectFill;
+}
+
+- (AVSampleBufferDisplayLayer *)sampleBufferDisplayLayer {
+  return (AVSampleBufferDisplayLayer *)self.layer;
+}
+
+- (AVLayerVideoGravity)videoGravity {
+  return self.sampleBufferDisplayLayer.videoGravity;
+}
+
+- (void)setVideoGravity:(AVLayerVideoGravity)videoGravity {
+  self.sampleBufferDisplayLayer.videoGravity = videoGravity;
+}
+
+- (void)setEnabled:(BOOL)enabled {
+  _enabled = enabled;
+  if (!enabled) {
+    // Flush when disabling so stale frames are removed immediately.
+    [self.sampleBufferDisplayLayer flush];
+  }
+}
+
+#pragma mark - RTCVideoRenderer
+
+- (void)setSize:(CGSize)size {
+  __weak RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer) *weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer) *strongSelf = weakSelf;
+
+    // Called by WebRTC when stream dimensions change.
+    strongSelf.videoSize = size;
+    
+    [strongSelf setNeedsLayout];
+    
+    // Delegate callbacks are delivered on main, matching existing renderers.
+    [strongSelf.delegate videoView:strongSelf didChangeVideoSize:size];
+  });
+}
+
+- (void)renderFrame:(nullable RTC_OBJC_TYPE(RTCVideoFrame) *)frame {
+  // Fast guard for common no-op cases.
+  if (!self.isEnabled) {
+    return;
+  }
+
+  if (frame == nil) {
+    RTCLogInfo(@"Incoming frame is nil. Exiting render callback.");
+    return;
+  }
+
+  // Capture target size on caller thread so background work does not touch
+  // UIKit properties directly.
+  CGSize targetSize = [self targetSizeForFrame:frame];
+  __weak RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer) *weakSelf = self;
+  // Conversion work can be expensive; run it off WebRTC callback thread.
+  dispatch_async(self.renderQueue, ^{
+    RTC_OBJC_TYPE(RTCPictureInPictureVideoRenderer) *strongSelf = weakSelf;
+    if (!strongSelf || !strongSelf.isEnabled) {
+      return;
+    }
+
+    // Build sample buffer from frame in backend/policy agnostic way.
+    CMSampleBufferRef sampleBuffer =
+        [strongSelf.frameConverter copySampleBufferFromFrame:frame
+                                                  targetSize:targetSize];
+    if (!sampleBuffer) {
+      return;
+    }
+
+    // Interact with AVSampleBufferDisplayLayer on main.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      __strong __typeof(weakSelf) innerSelf = weakSelf;
+      if (!innerSelf || !innerSelf.isEnabled) {
+        CFRelease(sampleBuffer);
+        return;
+      }
+
+      AVSampleBufferDisplayLayer *displayLayer = innerSelf.sampleBufferDisplayLayer;
+      // Some decoder states require flush before enqueueing new data.
+      if (@available(iOS 14.0, *)) {
+        if (displayLayer.requiresFlushToResumeDecoding) {
+          [displayLayer flush];
+        }
+      }
+
+      // Recover from failed rendering state by flushing layer queue.
+      if (displayLayer.status == AVQueuedSampleBufferRenderingStatusFailed) {
+        [displayLayer flush];
+      }
+
+      // Respect backpressure; drop frame if layer is saturated.
+      if (displayLayer.isReadyForMoreMediaData) {
+        [displayLayer enqueueSampleBuffer:sampleBuffer];
+      }
+
+      // Balance retained CoreFoundation ownership from converter.
+      CFRelease(sampleBuffer);
+    });
+  });
+}
+
+#pragma mark - Cross platform
+
+#if TARGET_OS_IPHONE
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self performLayout];
+}
+#elif TARGET_OS_OSX
+- (void)layout {
+  [super layout];
+  [self performLayout];
+}
+
+- (void)setNeedsLayout {
+  self.needsLayout = YES;
+}
+#endif
+
+#pragma mark - Private
+
+- (void)performLayout {
+  // Capture bounds changes so target sizing can happen off main thread
+  // without reading UIKit state from background queues.
+  self.rendererSize = self.bounds.size;
+}
+
+- (CGSize)targetSizeForFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame {
+  // Preferred path for PiP:
+  // scale to current renderer bounds when enabled.
+  if (self.resizesFramesToRendererSize &&
+      self.rendererSize.width > 0 &&
+      self.rendererSize.height > 0) {
+    return self.rendererSize;
+  }
+  // Secondary path:
+  // use the latest size reported by WebRTC's `setSize`.
+  if (self.videoSize.width > 0 && self.videoSize.height > 0) {
+    return self.videoSize;
+  }
+  // Final fallback:
+  // use frame's raw dimensions.
+  return CGSizeMake(frame.width, frame.height);
+}
+
+@end
+
+#endif

--- a/sdk/objc/components/renderer/pip/RTCVideoFrameConverter.h
+++ b/sdk/objc/components/renderer/pip/RTCVideoFrameConverter.h
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <AVFoundation/AVFoundation.h>
+
+#import "RTCVideoFrame.h"
+#import "sdk/objc/base/RTCMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+/**
+ * Converts WebRTC `RTCVideoFrame` instances into AVFoundation-friendly media.
+ *
+ * This type is intentionally backend/policy agnostic.
+ * Depending on renderer backend and frame-buffer policy, WebRTC can surface
+ * frames as:
+ * - native NV12 buffers,
+ * - I420 buffers,
+ * - custom buffers that expose `toI420`,
+ * - buffers that can directly expose a `CVPixelBuffer`.
+ *
+ * PiP rendering via `AVSampleBufferDisplayLayer` needs `CMSampleBuffer`
+ * objects. This converter centralizes the conversion contract so callers do
+ * not branch on frame-buffer implementation details.
+ *
+ * Conversion goals:
+ * 1. Preserve live-call rendering semantics (timestamps and frame order).
+ * 2. Prefer zero/low-copy fast paths when a native pixel buffer exists.
+ * 3. Fall back to deterministic I420 -> NV12 conversion when needed.
+ * 4. Keep one stable public API regardless of active WebRTC internals.
+ *
+ * Threading:
+ * - Callers typically use one converter from one serial render queue.
+ * - Internally, pixel-buffer pool access is synchronized for safety.
+ */
+RTC_OBJC_EXPORT
+@interface RTC_OBJC_TYPE(RTCVideoFrameConverter) : NSObject
+
+/**
+ * Returns a retained NV12 `CVPixelBuffer` for the input frame.
+ *
+ * Conversion strategy:
+ * - Prefer direct `pixelBuffer` export from the source frame buffer.
+ * - If unavailable, convert through `toI420`, then pack to NV12.
+ *
+ * Output format:
+ * - `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange` (NV12, full range),
+ *   chosen for AVFoundation compatibility and efficient iOS render paths.
+ *
+ * `targetSize` behavior:
+ * - If zero/invalid, the source frame dimensions are used.
+ * - If provided, the converter attempts full-frame scale using
+ *   `cropAndScaleWith:...` when supported by the concrete buffer type.
+ * - Size is normalized to at least `1x1`.
+ *
+ * Ownership:
+ * - Returned buffer follows CoreFoundation ownership rules
+ *   (`CF_RETURNS_RETAINED`): caller must release.
+ */
+- (nullable CVPixelBufferRef)
+    copyPixelBufferFromFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame
+                  targetSize:(CGSize)targetSize CF_RETURNS_RETAINED;
+
+/**
+ * Returns a retained `CMSampleBuffer` for the input frame.
+ *
+ * Internally:
+ * 1. Calls `copyPixelBufferFromFrame:targetSize:`.
+ * 2. Builds a `CMVideoFormatDescription` from the image buffer.
+ * 3. Wraps both into a `CMSampleBuffer`.
+ * 4. Uses `frame.timeStampNs` as presentation timestamp.
+ * 5. Marks attachment `kCMSampleAttachmentKey_DisplayImmediately` for
+ *    low-latency live rendering.
+ *
+ * Ownership:
+ * - Returned sample buffer is retained (`CF_RETURNS_RETAINED`): caller must
+ *   release.
+ */
+- (nullable CMSampleBufferRef)
+    copySampleBufferFromFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame
+                   targetSize:(CGSize)targetSize CF_RETURNS_RETAINED;
+
+@end
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/sdk/objc/components/renderer/pip/RTCVideoFrameConverter.mm
+++ b/sdk/objc/components/renderer/pip/RTCVideoFrameConverter.mm
@@ -1,0 +1,374 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import "RTCVideoFrameConverter.h"
+
+#if TARGET_OS_IPHONE && (!defined(TARGET_OS_VISION) || !TARGET_OS_VISION)
+
+#import <CoreMedia/CoreMedia.h>
+
+#include <algorithm>
+
+#import "base/RTCI420Buffer.h"
+#import "base/RTCVideoFrame.h"
+#import "base/RTCVideoFrameBuffer.h"
+#include "third_party/libyuv/include/libyuv/convert.h"
+
+namespace {
+
+// Normalizes caller-provided target size:
+// - If caller passes `.zero`, we preserve the frame's original resolution.
+// - We clamp to at least 1x1 to avoid invalid scaling inputs.
+static CGSize NormalizeTargetSize(CGSize targetSize, int width, int height) {
+  if (targetSize.width <= 0 || targetSize.height <= 0) {
+    return CGSizeMake(width, height);
+  }
+  int target_width = std::max(1, static_cast<int>(targetSize.width));
+  int target_height = std::max(1, static_cast<int>(targetSize.height));
+  return CGSizeMake(target_width, target_height);
+}
+
+}  // namespace
+
+@interface RTC_OBJC_TYPE(RTCVideoFrameConverter) () {
+  // Reused pool for NV12 output buffers. This avoids per-frame allocations
+  // when the output size is stable, which is common during active PiP.
+  CVPixelBufferPoolRef _pixelBufferPool;
+  // Tracks current pool dimensions so we can rebuild only on size changes.
+  int _poolWidth;
+  int _poolHeight;
+}
+
+@end
+
+@implementation RTC_OBJC_TYPE(RTCVideoFrameConverter)
+
+- (void)dealloc {
+  // Release CoreFoundation resources owned by this converter instance.
+  if (_pixelBufferPool) {
+    CVPixelBufferPoolRelease(_pixelBufferPool);
+    _pixelBufferPool = nil;
+  }
+}
+
+- (CVPixelBufferRef)copyPixelBufferFromFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame
+                                  targetSize:(CGSize)targetSize {
+  // Defensive guard: converter never crashes on nil/invalid frame input.
+  if (!frame || !frame.buffer) {
+    return nil;
+  }
+
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> buffer = frame.buffer;
+  // Normalize requested output size once so all subsequent paths agree.
+  CGSize normalized =
+      NormalizeTargetSize(targetSize, frame.buffer.width, frame.buffer.height);
+  // If the source buffer supports crop/scale, apply it before conversion.
+  // This keeps conversion work proportional to final PiP output size.
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> workingBuffer =
+      [self maybeScaleBuffer:buffer targetSize:normalized];
+
+  // Fast path:
+  // Some WebRTC buffers can expose a native CVPixelBuffer directly. If so,
+  // use that and avoid YUV plane conversions.
+  CVPixelBufferRef pixelBuffer =
+      [self copyPixelBufferFromFrameBuffer:workingBuffer];
+  if (pixelBuffer) {
+    // Keep resize semantics consistent across all buffer families:
+    // if caller requested a target size, only accept fast-path buffers that
+    // already match that size. Otherwise fall back to I420 path where scaling
+    // is guaranteed.
+    const size_t pixelBufferWidth = CVPixelBufferGetWidth(pixelBuffer);
+    const size_t pixelBufferHeight = CVPixelBufferGetHeight(pixelBuffer);
+    if (pixelBufferWidth == static_cast<size_t>(normalized.width) &&
+        pixelBufferHeight == static_cast<size_t>(normalized.height)) {
+      return pixelBuffer;
+    }
+
+    CVBufferRelease(pixelBuffer);
+  }
+
+  // Fallback path:
+  // Convert whatever we received to I420 (universal WebRTC software format).
+  id<RTC_OBJC_TYPE(RTCI420Buffer)> i420Buffer = [workingBuffer toI420];
+  if (!i420Buffer) {
+    return nil;
+  }
+  // I420 buffers can also support crop/scale; apply it so final output matches
+  // requested target dimensions.
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> scaledI420 =
+      [self maybeScaleBuffer:(id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)i420Buffer
+                  targetSize:normalized];
+  // Convert final I420 into NV12 CVPixelBuffer for AVFoundation consumption.
+  return [self copyPixelBufferFromI420Buffer:[scaledI420 toI420]];
+}
+
+- (CMSampleBufferRef)copySampleBufferFromFrame:(RTC_OBJC_TYPE(RTCVideoFrame) *)frame
+                                    targetSize:(CGSize)targetSize {
+  // Build on top of pixel-buffer conversion so format handling remains unified.
+  CVPixelBufferRef pixelBuffer = [self copyPixelBufferFromFrame:frame
+                                                      targetSize:targetSize];
+  if (!pixelBuffer) {
+    return nil;
+  }
+
+  // A format description is mandatory to wrap an image buffer in a sample
+  // buffer that AVSampleBufferDisplayLayer can decode/render.
+  CMFormatDescriptionRef formatDescription = nil;
+  OSStatus formatStatus =
+      CMVideoFormatDescriptionCreateForImageBuffer(
+          kCFAllocatorDefault,
+          pixelBuffer,
+          &formatDescription);
+  if (formatStatus != noErr || !formatDescription) {
+    CVBufferRelease(pixelBuffer);
+    return nil;
+  }
+
+  // Preserve frame timestamp so rendering order/timing stays consistent.
+  // Duration/decode TS are unknown in this display-only path.
+  CMSampleTimingInfo timingInfo = {
+      .duration = kCMTimeInvalid,
+      .presentationTimeStamp = CMTimeMake(frame.timeStampNs, 1000000000),
+      .decodeTimeStamp = kCMTimeInvalid};
+
+  CMSampleBufferRef sampleBuffer = nil;
+  OSStatus sampleStatus = CMSampleBufferCreateReadyWithImageBuffer(
+      kCFAllocatorDefault,
+      pixelBuffer,
+      formatDescription,
+      &timingInfo,
+      &sampleBuffer);
+
+  CFRelease(formatDescription);
+  CVBufferRelease(pixelBuffer);
+
+  if (sampleStatus != noErr || !sampleBuffer) {
+    return nil;
+  }
+
+  // Hint immediate display for live rendering scenarios (PiP/live call),
+  // reducing display latency compared to decode scheduling semantics.
+  CFArrayRef attachments =
+      CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, true);
+  if (attachments && CFArrayGetCount(attachments) > 0) {
+    CFMutableDictionaryRef dictionary = static_cast<CFMutableDictionaryRef>(
+        const_cast<void*>(CFArrayGetValueAtIndex(attachments, 0)));
+    CFDictionarySetValue(dictionary,
+                         kCMSampleAttachmentKey_DisplayImmediately,
+                         kCFBooleanTrue);
+  }
+
+  return sampleBuffer;
+}
+
+#pragma mark - Private
+
+- (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)maybeScaleBuffer:
+            (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)buffer
+                                             targetSize:(CGSize)targetSize {
+  // Scaling is opportunistic:
+  // - If unsupported by this buffer type, return original buffer untouched.
+  // - This keeps the converter compatible with arbitrary custom buffers.
+  if (!buffer ||
+      ![buffer respondsToSelector:@selector(cropAndScaleWith:offsetY:cropWidth:
+                                              cropHeight:scaleWidth:scaleHeight:)]) {
+    return buffer;
+  }
+
+  int sourceWidth = buffer.width;
+  int sourceHeight = buffer.height;
+  int targetWidth = std::max(1, static_cast<int>(targetSize.width));
+  int targetHeight = std::max(1, static_cast<int>(targetSize.height));
+
+  if (sourceWidth == targetWidth && sourceHeight == targetHeight) {
+    return buffer;
+  }
+
+  // Scale full source frame to target output dimensions.
+  // We don't crop content here; caller controls layout policy externally.
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> scaledBuffer =
+      [buffer cropAndScaleWith:0
+                       offsetY:0
+                     cropWidth:sourceWidth
+                    cropHeight:sourceHeight
+                    scaleWidth:targetWidth
+                   scaleHeight:targetHeight];
+  return scaledBuffer ?: buffer;
+}
+
+- (CVPixelBufferRef)copyPixelBufferFromFrameBuffer:
+    (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)buffer {
+  if (!buffer) {
+    return nil;
+  }
+
+  // Unified API access:
+  // `pixelBuffer` is optional on RTCVideoFrameBuffer; use it when available.
+  // Retain before returning to make ownership explicit to the caller.
+  if ([buffer respondsToSelector:@selector(pixelBuffer)]) {
+    CVPixelBufferRef pixelBuffer = buffer.pixelBuffer;
+    if (pixelBuffer) {
+      CVBufferRetain(pixelBuffer);
+      return pixelBuffer;
+    }
+  }
+
+  return nil;
+}
+
+- (CVPixelBufferRef)copyPixelBufferFromI420Buffer:
+    (id<RTC_OBJC_TYPE(RTCI420Buffer)>)i420Buffer {
+  if (!i420Buffer) {
+    return nil;
+  }
+
+  // Some I420 implementations may already expose a cached/derived CVPixelBuffer.
+  // Prefer that to avoid redundant conversion work.
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> frameBuffer =
+      (id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)>)i420Buffer;
+  if ([frameBuffer respondsToSelector:@selector(pixelBuffer)]) {
+    CVPixelBufferRef nativePixelBuffer = frameBuffer.pixelBuffer;
+    if (nativePixelBuffer) {
+      CVBufferRetain(nativePixelBuffer);
+      return nativePixelBuffer;
+    }
+  }
+
+  int width = i420Buffer.width;
+  int height = i420Buffer.height;
+  // Get a destination NV12 pixel buffer (pool-backed when possible).
+  CVPixelBufferRef pixelBuffer =
+      [self copyOrCreatePixelBufferWithWidth:width height:height];
+  if (!pixelBuffer) {
+    return nil;
+  }
+
+  CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+
+  uint8_t* dstY =
+      static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+  uint8_t* dstUV =
+      static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+  if (!dstY || !dstUV) {
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+    CVBufferRelease(pixelBuffer);
+    return nil;
+  }
+
+  int dstStrideY =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0));
+  int dstStrideUV =
+      static_cast<int>(CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1));
+
+  // Conversion target is NV12 because:
+  // - It's supported by AVSampleBufferDisplayLayer.
+  // - It maps efficiently to iOS video render/decode paths.
+  int result = libyuv::I420ToNV12(
+      i420Buffer.dataY,
+      i420Buffer.strideY,
+      i420Buffer.dataU,
+      i420Buffer.strideU,
+      i420Buffer.dataV,
+      i420Buffer.strideV,
+      dstY,
+      dstStrideY,
+      dstUV,
+      dstStrideUV,
+      width,
+      height);
+
+  CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+
+  if (result != 0) {
+    CVBufferRelease(pixelBuffer);
+    return nil;
+  }
+
+  return pixelBuffer;
+}
+
+- (CVPixelBufferRef)copyOrCreatePixelBufferWithWidth:(int)width
+                                               height:(int)height {
+  if (width <= 0 || height <= 0) {
+    return nil;
+  }
+
+  CVPixelBufferRef pixelBuffer = nil;
+
+  @synchronized(self) {
+    // Keep pool in sync with output dimensions.
+    // Reusing pool improves throughput and reduces allocation jitter.
+    [self ensurePoolWithWidth:width height:height];
+    if (_pixelBufferPool) {
+      CVReturn result = CVPixelBufferPoolCreatePixelBuffer(
+          kCFAllocatorDefault,
+          _pixelBufferPool,
+          &pixelBuffer);
+      if (result == kCVReturnSuccess && pixelBuffer) {
+        return pixelBuffer;
+      }
+    }
+  }
+
+  NSDictionary* attributes =
+      @{(id)kCVPixelBufferIOSurfacePropertiesKey : @{}};
+  // If pool allocation fails (pressure/creation failure), fallback to direct
+  // one-off allocation so rendering can continue.
+  CVReturn createResult = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+      (__bridge CFDictionaryRef)attributes,
+      &pixelBuffer);
+  if (createResult != kCVReturnSuccess) {
+    return nil;
+  }
+
+  return pixelBuffer;
+}
+
+- (void)ensurePoolWithWidth:(int)width height:(int)height {
+  // Fast no-op when the existing pool already matches target dimensions.
+  if (_pixelBufferPool && _poolWidth == width && _poolHeight == height) {
+    return;
+  }
+
+  // Replace pool when size changes. Old pool is released after outstanding
+  // buffers are returned by CF ownership semantics.
+  if (_pixelBufferPool) {
+    CVPixelBufferPoolRelease(_pixelBufferPool);
+    _pixelBufferPool = nil;
+  }
+
+  _poolWidth = width;
+  _poolHeight = height;
+
+  // Keep a small prewarmed pool. PiP renderer is single-stream, so 2 is enough
+  // to reduce churn while avoiding unnecessary memory retention.
+  NSDictionary* poolAttributes =
+      @{(id)kCVPixelBufferPoolMinimumBufferCountKey : @2};
+  NSDictionary* pixelBufferAttributes = @{
+    (id)kCVPixelBufferPixelFormatTypeKey :
+        @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange),
+    (id)kCVPixelBufferWidthKey : @(width),
+    (id)kCVPixelBufferHeightKey : @(height),
+    (id)kCVPixelBufferIOSurfacePropertiesKey : @{}
+  };
+
+  CVPixelBufferPoolCreate(kCFAllocatorDefault,
+                          (__bridge CFDictionaryRef)poolAttributes,
+                          (__bridge CFDictionaryRef)pixelBufferAttributes,
+                          &_pixelBufferPool);
+}
+
+@end
+
+#endif


### PR DESCRIPTION
## Summary
  This PR introduces an iOS Picture-in-Picture rendering path for WebRTC video tracks using AVFoundation sample-buffer rendering.

  ## Changes
  - Added `RTCPictureInPictureVideoRenderer`, a `UIView` + `RTCVideoRenderer` that accepts `RTCVideoFrame` and renders through `AVSampleBufferDisplayLayer`.
  - Added `RTCVideoFrameConverter` to convert `RTCVideoFrame` into NV12 `CVPixelBuffer` and `CMSampleBuffer`.
  - Added scaling support in the converter and reused `CVPixelBufferPool` allocation for stable live rendering.
  - Added fast-path pixel-buffer support by extending `RTCVideoFrameBuffer` with optional `pixelBuffer`.
  - Updated `RTCNativeI420Buffer` with cached NV12 pixel-buffer export.
  - Updated `RTCNativeNV12Buffer` with cached pixel-buffer export and `cropAndScaleWith(...)`.
  - Updated `sdk/BUILD.gn` with new PiP source/header entries and AVFoundation/CoreMedia framework dependencies.

  ## Why
  PiP rendering on iOS requires a sample-buffer based AVFoundation path. This change adds a backend-agnostic bridge from WebRTC frame buffers to AVFoundation media buffers without coupling app code to buffer internals.

  ## Test Plan
  1. Build the iOS ObjC SDK target with the new renderer and converter sources.
  2. Attach `RTCPictureInPictureVideoRenderer` to a live `RTCVideoTrack`.
  3. Verify normal rendering and PiP rendering both work.
  4. Verify resize behavior for track size changes and renderer bounds changes.
  5. Verify renderer disable/enable behavior and recovery from display layer flush/error states.
  6. Verify mixed buffer types (native NV12, I420, and `toI420` fallbacks) render without crashes.