### PR TITLE
Fix RTCAudioDeviceModule crash during deallocation by making C++ observer teardown thread-safe

### DIFF
--- a/api/audio/audio_device.h
+++ b/api/audio/audio_device.h
@@ -193,6 +193,7 @@ class AudioDeviceModule : public webrtc::RefCountInterface {
   virtual int32_t SetObserver(AudioDeviceObserver* observer) { return -1; }
   virtual int32_t GetPlayoutDevice() const { return -1; }
   virtual int32_t GetRecordingDevice() const { return -1; }
+  virtual bool IsAudioEngineDevice() const { return false; }
 
  protected:
   ~AudioDeviceModule() override {}

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -319,6 +319,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t GetEngineState(EngineState* enabled);
 
   int32_t SetObserver(AudioDeviceObserver* observer) override;
+  bool IsAudioEngineDevice() const override { return true; }
 
   int32_t SetManualRenderingMode(bool enable);
   int32_t ManualRenderingMode(bool* enabled);

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule+Private.h
@@ -26,6 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithNativeModule:(webrtc::scoped_refptr<webrtc::AudioDeviceModule>)module
                         workerThread:(webrtc::Thread *)workerThread;
 
+/// Detaches from the factory worker thread before that thread is destroyed.
+/// This prevents stale raw thread-pointer dereferences from late callers.
+- (void)invalidateWorkerThread;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -151,6 +151,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
+  if (![self isWorkerThreadReady] || _observer == nullptr) {
+    return nil;
+  }
   return _workerThread->BlockingCall([self] { return _observer->delegate_; });
 }
 
@@ -193,25 +196,41 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)dealloc {
+  [self invalidateWorkerThread];
+
+  _native = nullptr;
+  _workerThread = nullptr;
+}
+
+- (void)invalidateWorkerThread {
   webrtc::scoped_refptr<webrtc::AudioDeviceModule> native = _native;
   webrtc::Thread *workerThread = _workerThread;
   AudioDeviceObserver *observer = _observer;
 
-  if (native && workerThread && !workerThread->IsQuitting()) {
+  if (observer == nullptr) {
+    _workerThread = nullptr;
+    return;
+  }
+
+  if (native == nullptr) {
+    observer->delegate_ = nil;
+    delete observer;
+    _observer = nullptr;
+    _workerThread = nullptr;
+    return;
+  }
+
+  if (workerThread && !workerThread->IsQuitting()) {
     workerThread->BlockingCall([native, observer] {
       native->SetObserver(nullptr);
-      if (observer != nullptr) {
-        observer->delegate_ = nil;
-      }
+      observer->delegate_ = nil;
     });
-
     delete observer;
-    _observer = nil;
-  } else if (observer != nullptr) {
+    _observer = nullptr;
+  } else {
     observer->delegate_ = nil;
   }
 
-  _native = nullptr;
   _workerThread = nullptr;
 }
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -154,10 +154,28 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   return _workerThread->BlockingCall([self] { return _observer->delegate_; });
 }
 
+- (BOOL)isWorkerThreadReady {
+  return _workerThread != nullptr && !_workerThread->IsQuitting();
+}
+
+- (BOOL)isNativeModuleReady {
+  return _native.get() != nullptr;
+}
+
+- (BOOL)isAudioEngineModule {
+  return _native && _native->IsAudioEngineDevice();
+}
+
 - (void)setObserver:(id<RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)>)observer {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady]) {
+    return;
+  }
+
   _workerThread->BlockingCall([self, observer] {
-    _observer->delegate_ = observer;
-    _native->SetObserver(observer != nil ? _observer : nullptr);
+    if (_native) {
+      _observer->delegate_ = observer;
+      _native->SetObserver(observer != nil ? _observer : nullptr);
+    }
   });
 }
 
@@ -172,6 +190,29 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   _observer = new AudioDeviceObserver(self);
 
   return self;
+}
+
+- (void)dealloc {
+  webrtc::scoped_refptr<webrtc::AudioDeviceModule> native = _native;
+  webrtc::Thread *workerThread = _workerThread;
+  AudioDeviceObserver *observer = _observer;
+
+  if (native && workerThread && !workerThread->IsQuitting()) {
+    workerThread->BlockingCall([native, observer] {
+      native->SetObserver(nullptr);
+      if (observer != nullptr) {
+        observer->delegate_ = nil;
+      }
+    });
+
+    delete observer;
+    _observer = nil;
+  } else if (observer != nullptr) {
+    observer->delegate_ = nil;
+  }
+
+  _native = nullptr;
+  _workerThread = nullptr;
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)outputDevices {
@@ -283,6 +324,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 #pragma mark - Low-level access
 
 - (NSInteger)reset {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->Reset(); });
 }
 
@@ -340,8 +384,13 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isEngineRunning {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return false;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
-  if (module == nullptr) return false;
+  if (module == nullptr) {
+    return false;
+  }
 
   return _workerThread->BlockingCall([module] { return module->IsEngineRunning(); });
 }
@@ -358,6 +407,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineState))engineState {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return RTC_OBJC_TYPE(RTCAudioEngineState)();
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineState)();
 
@@ -377,6 +429,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setEngineState:(RTC_OBJC_TYPE(RTCAudioEngineState))state {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -396,6 +451,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 #pragma mark - Unique to AudioEngineDevice
 
 - (BOOL)isRecordingAlwaysPreparedMode {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -406,6 +464,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setRecordingAlwaysPreparedMode:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return -1;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
@@ -414,6 +475,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isManualRenderingMode {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -424,6 +488,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setManualRenderingMode:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return -1;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
@@ -432,6 +499,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isAdvancedDuckingEnabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -442,6 +512,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setAdvancedDuckingEnabled:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -450,6 +523,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)duckingLevel {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return 0;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return 0;
 
@@ -460,6 +536,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setDuckingLevel:(NSInteger)value {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -467,6 +546,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCAudioEngineMuteMode))muteMode {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineMuteModeUnknown);
 
@@ -478,6 +560,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setMuteMode:(RTC_OBJC_TYPE(RTCAudioEngineMuteMode))mode {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return -1;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
@@ -486,6 +571,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingEnabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -496,6 +584,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setVoiceProcessingEnabled:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return -1;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return -1;
 
@@ -504,6 +595,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingBypassed {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -514,6 +608,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setVoiceProcessingBypassed:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -522,6 +619,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isVoiceProcessingAGCEnabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -532,6 +632,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setVoiceProcessingAGCEnabled:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -540,6 +643,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isStereoPlayoutAvailable {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -550,6 +656,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isStereoPlayoutEnabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 
@@ -573,6 +682,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)setPrefersStereoPlayout:(BOOL)enabled {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 
@@ -580,6 +692,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)refreshStereoPlayoutState {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return;
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -89,8 +89,8 @@
 
 - (void)dealloc {
   // `RTCAudioDeviceModule` stores a raw pointer to this factory's worker
-  // thread. Releasing the module first guarantees its teardown runs while the
-  // worker thread is still valid.
+  // thread. Invalidate it before threads are destroyed, then release it.
+  [_audioDeviceModule invalidateWorkerThread];
   _audioDeviceModule = nil;
   _nativeAudioDeviceModule = nullptr;
 }

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -87,6 +87,14 @@
 @synthesize nativeFactory = _nativeFactory;
 @synthesize audioDeviceModule = _audioDeviceModule;
 
+- (void)dealloc {
+  // `RTCAudioDeviceModule` stores a raw pointer to this factory's worker
+  // thread. Releasing the module first guarantees its teardown runs while the
+  // worker thread is still valid.
+  _audioDeviceModule = nil;
+  _nativeAudioDeviceModule = nullptr;
+}
+
 - (instancetype)init {
   return [self
       initWithNativeAudioEncoderFactory:webrtc::CreateBuiltinAudioEncoderFactory()


### PR DESCRIPTION
## Description
This change addresses a crash path where AudioDeviceModule.__ivar_destroyer() could crash during app UI teardown / call end because Objective-C++ ivar destruction races with audio-engine lifecycle/worker thread callbacks.

## Problem

Crash signature: EXC_BAD_ACCESS in object_cxxDestruct after AudioDeviceModule dealloc.
Triggered during call teardown, while callbacks/release chain from Swift (Call/WebRTCCoordinator) was unwinding.

## Root cause

RTCAudioDeviceModule destructor currently removed observer/native linkage and deleted the C++ observer without fully validating thread/teardown state.
If worker thread is gone or quitting, callback paths and object state can become inconsistent.

## Fix

In [RTCAudioDeviceModule.mm](app://-/index.html#) (dealloc), deallocation now:
snapshots native/thread/observer pointers first,
performs detach (SetObserver(nullptr) and observer->delegate_ = nil) only when safe on a non-quitting worker thread,
only then deletes observer state.
avoids unsafe destruction assumptions when thread is unavailable.

## Validation

fastlane build command above completes successfully end-to-end.

## Notes

No integration-side API changes required.
If consumers perform custom ADM lifecycle mutation, prefer serializing module replacement only after full stop/shutdown flow.