### PR TITLE
Iliaspavlidakis/ios 1482 bugwebrtc crash while rotating the device during joining the

### DIFF
--- a/media/engine/fake_webrtc_call.h
+++ b/media/engine/fake_webrtc_call.h
@@ -100,6 +100,7 @@ class FakeAudioSendStream final : public AudioSendStream {
                           int payload_frequency,
                           int event,
                           int duration_ms) override;
+  bool GetMuted() override { return muted_; }
   void SetMuted(bool muted) override;
   AudioSendStream::Stats GetStats() const override;
   AudioSendStream::Stats GetStats(bool has_remote_tracks) const override;

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -31,12 +31,37 @@
 #include "api/video_codecs/video_encoder.h"
 #include "modules/video_coding/include/video_codec_interface.h"
 #include "modules/video_coding/include/video_error_codes.h"
+#include "rtc_base/time_utils.h"
 #include "rtc_base/logging.h"
+#include "sdk/objc/native/src/objc_frame_buffer.h"
 #include "sdk/objc/native/src/objc_video_frame.h"
 
 namespace webrtc {
 
 namespace {
+
+RTC_OBJC_TYPE(RTCVideoFrame) *ToObjCVideoFrameForEncoder(
+    const VideoFrame &frame) {
+  id<RTC_OBJC_TYPE(RTCVideoFrameBuffer)> frame_buffer = nil;
+  const webrtc::scoped_refptr<VideoFrameBuffer> buffer =
+      frame.video_frame_buffer();
+
+  if (buffer && buffer->type() == VideoFrameBuffer::Type::kNative) {
+    frame_buffer = static_cast<ObjCFrameBuffer *>(buffer.get())
+                       ->wrapped_frame_buffer();
+  } else {
+    frame_buffer = ToObjCVideoFrameBuffer(buffer);
+  }
+
+  RTC_OBJC_TYPE(RTCVideoFrame) *video_frame =
+      [[RTC_OBJC_TYPE(RTCVideoFrame) alloc]
+          initWithBuffer:frame_buffer
+                rotation:RTC_OBJC_TYPE(RTCVideoRotation)(frame.rotation())
+             timeStampNs:frame.timestamp_us() *
+                         webrtc::kNumNanosecsPerMicrosec];
+  video_frame.timeStamp = frame.rtp_timestamp();
+  return video_frame;
+}
 
 class ObjCVideoEncoder : public VideoEncoder {
  public:
@@ -91,7 +116,7 @@ class ObjCVideoEncoder : public VideoEncoder {
       [rtcFrameTypes addObject:@(RTC_OBJC_TYPE(RTCFrameType)(frame_types->at(i)))];
     }
 
-    return [encoder_ encode:ToObjCVideoFrame(frame)
+    return [encoder_ encode:ToObjCVideoFrameForEncoder(frame)
           codecSpecificInfo:nil
                  frameTypes:rtcFrameTypes];
   }

--- a/sdk/objc/unittests/objc_video_encoder_factory_tests.mm
+++ b/sdk/objc/unittests/objc_video_encoder_factory_tests.mm
@@ -25,6 +25,7 @@
 #include "modules/video_coding/include/video_error_codes.h"
 #include "rtc_base/gunit.h"
 #include "sdk/objc/native/src/objc_frame_buffer.h"
+#include "sdk/objc/native/src/objc_nv12_conversion.h"
 
 id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)> CreateEncoderFactoryReturning(
     int return_code) {
@@ -193,6 +194,67 @@ std::unique_ptr<webrtc::VideoEncoder> GetObjCEncoder(
   std::vector<webrtc::VideoFrameType> frame_types;
 
   EXPECT_EQ(encoder->Encode(frame, &frame_types), WEBRTC_VIDEO_CODEC_ERROR);
+}
+
+- (void)testEncodeBypassesFrameBufferPolicyForNativeBuffers {
+  __block RTC_OBJC_TYPE(RTCVideoFrame) *capturedFrame = nil;
+
+  id encoderMock = OCMProtocolMock(@protocol(RTC_OBJC_TYPE(RTCVideoEncoder)));
+  OCMStub([encoderMock startEncodeWithSettings:[OCMArg any] numberOfCores:1])
+      .andReturn(WEBRTC_VIDEO_CODEC_OK);
+  OCMStub([encoderMock encode:[OCMArg any]
+              codecSpecificInfo:[OCMArg any]
+                     frameTypes:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained RTC_OBJC_TYPE(RTCVideoFrame) *frameArg = nil;
+        [invocation getArgument:&frameArg atIndex:2];
+        capturedFrame = frameArg;
+      })
+      .andReturn(WEBRTC_VIDEO_CODEC_OK);
+  OCMStub([encoderMock releaseEncoder]).andReturn(WEBRTC_VIDEO_CODEC_OK);
+  OCMStub([encoderMock setBitrate:0 framerate:0]).andReturn(WEBRTC_VIDEO_CODEC_OK);
+  OCMStub([encoderMock implementationName]).andReturn(@"mock");
+
+  id encoderFactoryMock =
+      OCMProtocolMock(@protocol(RTC_OBJC_TYPE(RTCVideoEncoderFactory)));
+  RTC_OBJC_TYPE(RTCVideoCodecInfo) *supported =
+      [[RTC_OBJC_TYPE(RTCVideoCodecInfo) alloc] initWithName:@"H264"
+                                                  parameters:nil];
+  OCMStub([encoderFactoryMock supportedCodecs]).andReturn(@[ supported ]);
+  OCMStub([encoderFactoryMock implementations]).andReturn(@[ supported ]);
+  OCMStub([encoderFactoryMock createEncoder:[OCMArg any]])
+      .andReturn(encoderMock);
+
+  const auto old_policy = webrtc::ObjCGetFrameBufferPolicy();
+  webrtc::SetObjCFrameBufferPolicy(webrtc::ObjCFrameBufferPolicy::kCopyToNV12);
+
+  CVPixelBufferRef pixel_buffer = nullptr;
+  CVPixelBufferCreate(kCFAllocatorDefault,
+                      640,
+                      480,
+                      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                      nil,
+                      &pixel_buffer);
+  webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer =
+      webrtc::make_ref_counted<webrtc::ObjCFrameBuffer>([[RTC_OBJC_TYPE(
+          RTCCVPixelBuffer) alloc] initWithPixelBuffer:pixel_buffer]);
+  webrtc::VideoFrame frame = webrtc::VideoFrame::Builder()
+                                 .set_video_frame_buffer(buffer)
+                                 .set_rotation(webrtc::kVideoRotation_0)
+                                 .set_timestamp_us(0)
+                                 .build();
+  std::vector<webrtc::VideoFrameType> frame_types;
+
+  @try {
+    std::unique_ptr<webrtc::VideoEncoder> encoder =
+        GetObjCEncoder(encoderFactoryMock);
+    EXPECT_EQ(encoder->Encode(frame, &frame_types), WEBRTC_VIDEO_CODEC_OK);
+    EXPECT_TRUE([capturedFrame.buffer
+        isKindOfClass:[RTC_OBJC_TYPE(RTCCVPixelBuffer) class]]);
+  } @finally {
+    webrtc::SetObjCFrameBufferPolicy(old_policy);
+    CVBufferRelease(pixel_buffer);
+  }
 }
 
 - (void)testReleaseEncodeReturnsOKOnSuccess {


### PR DESCRIPTION
## Issues

Resolves https://linear.app/stream/issue/IOS-1482/bugwebrtc-crash-while-rotating-the-device-during-joining-the-call

## Summary

This changes the ObjC encoder bridge so native frame buffers are preserved on the encode path instead of being rewritten by the global `RTCFrameBufferPolicy`.

## Problem

`RTCFrameBufferPolicy` is useful for ObjC-side consumers like rendering, but the same conversion logic was also being applied when bridging native `VideoFrame` input into the ObjC encoder path.

With `bufferPolicy = .copyToNV12`, that meant native `RTCCVPixelBuffer` input could be rewritten before it reached the VideoToolbox encoder flow. That is the wrong layer to apply the policy for encoding and is a plausible trigger for the crash seen during live publishing/orientation changes.

## Fix

- Preserve wrapped native buffers when converting `VideoFrame` to `RTCVideoFrame` for the ObjC encoder bridge.
- Keep the existing `RTCFrameBufferPolicy` behavior for the normal ObjC frame-buffer conversion path used elsewhere.
- Add a regression test that verifies `.copyToNV12` does not rewrite native buffers on the encoder path.
- Add the missing `FakeAudioSendStream::GetMuted()` override required for `sdk_unittests` to build with the current interface.

## Steps To Reproduce

1. Use an app build that includes `stream-video-swift` `1.43.0`.
2. Configure the app to publish local video with `bufferPolicy = .copyToNV12`.
3. Start joining a call as a participant who will publish video.
4. While the call is still joining, continuously rotate the device between portrait and landscape.
5. Repeat until the local video pipeline transitions through capture/encode setup during orientation changes.

## Validation

- Built `sdk_unittests` for iOS simulator.
- Ran `ObjCVideoEncoderFactoryTests`.
- Verified `testEncodeBypassesFrameBufferPolicyForNativeBuffers` passes.
- Verified the full `ObjCVideoEncoderFactoryTests` suite passes: 12 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added audio device reset capability and stereo playout preference control with automatic availability detection.
  * Introduced Metal-based video rendering with configurable frame buffer policies for optimized performance.
  * Added Picture-in-Picture video renderer for iOS with gravity and sizing controls.
  * Enabled NV12 video buffer support with native pixel buffer conversion and scaling capabilities.
  * Added audio processing state notifications to track voice processing and stereo playout changes.

* **Improvements**
  * Enhanced video encoders with low-latency fallback mechanism when primary encoder unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->