### PR TITLE
[Fix]AudioEngine ADM teardown after factory dealloc

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1349,6 +1349,7 @@ if (is_ios || is_mac) {
             "objc/unittests/RTCMediaConstraintsTest.mm",
             "objc/unittests/RTCNV12TextureCache_xctest.m",
             "objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm",
+            "objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm",
             "objc/unittests/RTCPeerConnectionFactory_xctest.m",
             "objc/unittests/RTCPeerConnectionTest.mm",
             "objc/unittests/RTCSessionDescriptionTest.mm",

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -15,6 +15,7 @@
  */
 
 #include <os/lock.h>
+#include <utility>
 
 #import "RTCAudioDeviceModule+Private.h"
 #import "RTCAudioDeviceModule.h"
@@ -165,6 +166,10 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   return _native.get() != nullptr;
 }
 
+- (BOOL)isModuleReady {
+  return [self isNativeModuleReady] && [self isWorkerThreadReady];
+}
+
 - (BOOL)isAudioEngineModule {
   return _native && _native->IsAudioEngineDevice();
 }
@@ -203,7 +208,6 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (void)invalidateWorkerThread {
-  webrtc::scoped_refptr<webrtc::AudioDeviceModule> native = _native;
   webrtc::Thread *workerThread = _workerThread;
   AudioDeviceObserver *observer = _observer;
 
@@ -212,7 +216,7 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
     return;
   }
 
-  if (native == nullptr) {
+  if (_native == nullptr) {
     observer->delegate_ = nil;
     delete observer;
     _observer = nullptr;
@@ -221,9 +225,13 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
   }
 
   if (workerThread && !workerThread->IsQuitting()) {
-    workerThread->BlockingCall([native, observer] {
+    // Drop the wrapper's native ADM ref on the worker thread so teardown runs
+    // while the thread stored inside the ADM is still valid.
+    webrtc::scoped_refptr<webrtc::AudioDeviceModule> native = std::move(_native);
+    workerThread->BlockingCall([&native, observer] {
       native->SetObserver(nullptr);
       observer->delegate_ = nil;
+      native = nullptr;
     });
     delete observer;
     _observer = nullptr;
@@ -235,14 +243,23 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)outputDevices {
+  if (![self isModuleReady]) {
+    return @[];
+  }
   return _workerThread->BlockingCall([self] { return [self _outputDevices]; });
 }
 
 - (NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *)inputDevices {
+  if (![self isModuleReady]) {
+    return @[];
+  }
   return _workerThread->BlockingCall([self] { return [self _inputDevices]; });
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)outputDevice {
+  if (![self isModuleReady]) {
+    return nil;
+  }
   return _workerThread->BlockingCall([self] {
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _outputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
@@ -261,6 +278,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)trySetOutputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self, device] {
     NSUInteger index = 0;
     NSArray *devices = [self _outputDevices];
@@ -288,6 +308,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (RTC_OBJC_TYPE(RTCIODevice) *)inputDevice {
+  if (![self isModuleReady]) {
+    return nil;
+  }
   return _workerThread->BlockingCall([self] {
     NSArray<RTC_OBJC_TYPE(RTCIODevice) *> *devices = [self _inputDevices];
     int16_t devicesCount = (int16_t)([devices count]);
@@ -306,6 +329,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)trySetInputDevice:(RTC_OBJC_TYPE(RTCIODevice) *)device {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self, device] {
     NSUInteger index = 0;
     NSArray *devices = [self _inputDevices];
@@ -333,47 +359,74 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)playing {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->Playing(); });
 }
 
 - (BOOL)recording {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->Recording(); });
 }
 
 #pragma mark - Low-level access
 
 - (NSInteger)reset {
-  if (![self isNativeModuleReady] || ![self isWorkerThreadReady]) {
+  if (![self isModuleReady]) {
     return -1;
   }
   return _workerThread->BlockingCall([self] { return _native->Reset(); });
 }
 
 - (NSInteger)startPlayout {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->StartPlayout(); });
 }
 
 - (NSInteger)stopPlayout {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->StopPlayout(); });
 }
 
 - (NSInteger)initPlayout {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->InitPlayout(); });
 }
 
 - (NSInteger)startRecording {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->StartRecording(); });
 }
 
 - (NSInteger)stopRecording {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->StopRecording(); });
 }
 
 - (NSInteger)initRecording {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] { return _native->InitRecording(); });
 }
 
 - (NSInteger)initAndStartRecording {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self] {
     webrtc::AudioEngineDevice *engine_device =
         static_cast<webrtc::AudioEngineDevice *>(_native.get());
@@ -387,18 +440,30 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isPlayoutInitialized {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->PlayoutIsInitialized(); });
 }
 
 - (BOOL)isRecordingInitialized {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->RecordingIsInitialized(); });
 }
 
 - (BOOL)isPlaying {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->Playing(); });
 }
 
 - (BOOL)isRecording {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] { return _native->Recording(); });
 }
 
@@ -415,6 +480,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)isMicrophoneMuted {
+  if (![self isModuleReady]) {
+    return NO;
+  }
   return _workerThread->BlockingCall([self] {
     bool value = false;
     return _native->MicrophoneMute(&value) == 0 ? value : NO;
@@ -422,6 +490,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (NSInteger)setMicrophoneMuted:(BOOL)muted {
+  if (![self isModuleReady]) {
+    return -1;
+  }
   return _workerThread->BlockingCall([self, muted] { return _native->SetMicrophoneMute(muted); });
 }
 
@@ -688,6 +759,9 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 }
 
 - (BOOL)prefersStereoPlayout {
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return NO;
+  }
   webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
   if (module == nullptr) return NO;
 

--- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
+++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
@@ -89,10 +89,12 @@
 
 - (void)dealloc {
   // `RTCAudioDeviceModule` stores a raw pointer to this factory's worker
-  // thread. Invalidate it before threads are destroyed, then release it.
+  // thread. Release the factory's native ADM ref before invalidating the
+  // wrapper so the wrapper can tear the native module down on the worker
+  // thread instead of leaving it alive with a stale thread pointer.
+  _nativeAudioDeviceModule = nullptr;
   [_audioDeviceModule invalidateWorkerThread];
   _audioDeviceModule = nil;
-  _nativeAudioDeviceModule = nullptr;
 }
 
 - (instancetype)init {

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#include <vector>
+
+#import "api/peerconnection/RTCAudioDeviceModule.h"
+#import "api/peerconnection/RTCPeerConnectionFactory.h"
+#import "components/audio/RTCAudioSession+Private.h"
+
+@interface RTC_OBJC_TYPE(RTCAudioSession)
+(UnitTesting)
+
+@property(nonatomic, readonly) std::vector<
+    __weak id<RTC_OBJC_TYPE(RTCAudioSessionDelegate)> > delegates;
+
+@end
+
+@interface RTCPeerConnectionFactoryAudioEngineTests : XCTestCase
+@end
+
+@implementation RTCPeerConnectionFactoryAudioEngineTests
+
+- (void)testAudioEngineModuleRetainedAfterFactoryDeallocDoesNotKeepAudioSessionDelegate {
+  RTC_OBJC_TYPE(RTCAudioSession) *session =
+      [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
+  const size_t delegateCountBeforeFactory = session.delegates.size();
+
+  __attribute__((objc_precise_lifetime))
+  RTC_OBJC_TYPE(RTCAudioDeviceModule) *retainedAudioDeviceModule = nil;
+  @autoreleasepool {
+    RTC_OBJC_TYPE(RTCPeerConnectionFactory) *factory =
+        [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc]
+            initWithAudioDeviceModuleType:
+                RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine)
+                      bypassVoiceProcessing:NO
+                             encoderFactory:nil
+                             decoderFactory:nil
+                      audioProcessingModule:nil];
+    retainedAudioDeviceModule = factory.audioDeviceModule;
+
+    XCTAssertEqual(delegateCountBeforeFactory + 1, session.delegates.size());
+  }
+
+  const size_t delegateCountAfterFactory = session.delegates.size();
+  XCTAssertNotNil(retainedAudioDeviceModule);
+  XCTAssertEqual(
+      delegateCountBeforeFactory,
+      delegateCountAfterFactory,
+      @"Retaining the audio device module after the factory is released must "
+       @"not leave AudioEngineDevice registered with RTCAudioSession.");
+  XCTAssertEqual(0u, retainedAudioDeviceModule.outputDevices.count);
+  XCTAssertEqual(0u, retainedAudioDeviceModule.inputDevices.count);
+  XCTAssertNil(retainedAudioDeviceModule.outputDevice);
+  XCTAssertNil(retainedAudioDeviceModule.inputDevice);
+  XCTAssertFalse(retainedAudioDeviceModule.playing);
+  XCTAssertFalse(retainedAudioDeviceModule.recording);
+  XCTAssertFalse(retainedAudioDeviceModule.isEngineRunning);
+  XCTAssertFalse([retainedAudioDeviceModule trySetOutputDevice:nil]);
+  XCTAssertEqual(-1, [retainedAudioDeviceModule reset]);
+  XCTAssertEqual(-1, [retainedAudioDeviceModule startPlayout]);
+  XCTAssertEqual(-1, [retainedAudioDeviceModule stopPlayout]);
+  XCTAssertEqual(-1, [retainedAudioDeviceModule initRecording]);
+  [retainedAudioDeviceModule refreshStereoPlayoutState];
+
+  if (delegateCountAfterFactory == delegateCountBeforeFactory) {
+    AVAudioSessionRouteDescription *previousRoute =
+        [AVAudioSession sharedInstance].currentRoute;
+    [session notifyDidChangeRouteWithReason:
+                 AVAudioSessionRouteChangeReasonOldDeviceUnavailable
+                          previousRoute:previousRoute];
+  }
+
+  retainedAudioDeviceModule = nil;
+}
+
+@end


### PR DESCRIPTION
## Issues

Resolves https://linear.app/stream/issue/IOS-1483/bugwebrtc-crash-on-audioengine-after-call-left

## Summary

This fixes a crash in the AudioEngine-based ADM when `RTCAudioDeviceModule` outlives its `RTCPeerConnectionFactory`.

The crash happens on audio route changes (`AVAudioSessionRouteChangeNotification`) after the factory has already torn down its worker thread. In that state, `AudioEngineDevice` can still be registered as an `RTCAudioSession` delegate and attempts to post back to a dead `webrtc::Thread*`, causing the `EXC_BAD_ACCESS` seen in crash reports.

## Root cause

`RTCPeerConnectionFactory` owns the worker thread, but callers can retain `factory.audioDeviceModule` independently.

Before this change:
- the factory could be deallocated
- the worker thread could be destroyed
- the retained ObjC ADM wrapper could still keep the native `AudioEngineDevice` alive
- `AudioEngineDevice` remained registered with `RTCAudioSession`
- the next route change called `AudioEngineDevice::OnValidRouteChange()`
- that method called `thread_->PostTask(...)` on a stale raw thread pointer

## Repro

A consistent repro sequence is:

1. Create a `RTCPeerConnectionFactory` with `RTCAudioDeviceModuleTypeAudioEngine`.
2. Keep a strong reference to `factory.audioDeviceModule`.
3. Release the factory.
4. Trigger an audio route change:
   - plug/unplug wired headphones
   - connect/disconnect Bluetooth audio
   - switch speaker/receiver output
5. Observe a crash from `audioSessionDidChangeRoute -> OnValidRouteChange -> PostTask`.

## Changes

- Release the factory's native ADM reference before invalidating the ObjC ADM wrapper.
- During wrapper invalidation, drop the wrapper's native ADM reference on the worker thread so native teardown happens while the stored thread is still valid.
- Remove the stale `RTCAudioSession` delegate as part of that native teardown path.
- Harden `RTCAudioDeviceModule` so that, once detached from the factory, late calls fail closed instead of touching `_workerThread` or `_native`.
  - arrays return empty
  - object accessors return `nil`
  - booleans return `NO`
  - mutating calls return `-1` / `NO`
  - void methods become no-ops

## Tests

Added an iOS regression test that:
- creates an AudioEngine-backed factory
- retains `factory.audioDeviceModule`
- deallocates the factory
- verifies the `RTCAudioSession` delegate count returns to baseline
- verifies late calls on the retained wrapper are safe
- injects a route-change notification to confirm the stale delegate path is gone

## Verification

- Generated an iOS simulator build with:
  - `gn gen out/ios_sim_audioengine --args='target_os="ios" target_cpu="arm64" target_environment="simulator" enable_run_ios_unittests_with_xctest=true ios_enable_code_signing=false'`
- Ran direct clang compile-command checks for:
  - `sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm`
  - `sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm`
  - `sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm`
