### PR TITLE
Fix iOS playback volume drop after re-muting

### DIFF
--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -184,9 +184,10 @@ void AudioState::OnMuteStreamChanged() {
     if (!adm->Recording() && adm->InitRecording() == 0) {
       adm->StartRecording();
     }
-  } else {
-    adm->StopRecording();
   }
+  // Do not stop recording when all send streams are muted. On iOS, tearing
+  // down input recreates the audio graph as output-only and changes playout
+  // loudness; explicit SetRecording(false) and stream removal still stop input.
 }
 
 void AudioState::UpdateAudioTransportWithSendingStreams() {

--- a/audio/audio_state_unittest.cc
+++ b/audio/audio_state_unittest.cc
@@ -52,6 +52,7 @@ using ::testing::InSequence;
 using ::testing::Matcher;
 using ::testing::NiceMock;
 using ::testing::NotNull;
+using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::Values;
 
@@ -445,6 +446,29 @@ TEST_P(AudioStateTest, AlwaysCallInitRecordingBeforeStartRecording) {
     audio_state->SetRecording(true);
   }
 
+  EXPECT_CALL(*adm, StopRecording());
+  audio_state->RemoveSendingStream(&stream);
+}
+
+TEST_P(AudioStateTest, MuteStreamChangeDoesNotStopRecording) {
+  ConfigHelper helper(GetParam());
+  scoped_refptr<internal::AudioState> audio_state(
+      make_ref_counted<internal::AudioState>(helper.config()));
+
+  auto* adm = reinterpret_cast<MockAudioDeviceModule*>(
+      helper.config().audio_device_module.get());
+
+  MockAudioSendStream stream;
+  EXPECT_CALL(*adm, InitRecording());
+  EXPECT_CALL(*adm, StartRecording());
+  audio_state->AddSendingStream(&stream, kSampleRate, kNumberOfChannels);
+
+  EXPECT_CALL(stream, GetMuted()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*adm, StopRecording()).Times(0);
+  audio_state->OnMuteStreamChanged();
+
+  testing::Mock::VerifyAndClearExpectations(&stream);
+  testing::Mock::VerifyAndClearExpectations(adm);
   EXPECT_CALL(*adm, StopRecording());
   audio_state->RemoveSendingStream(&stream);
 }


### PR DESCRIPTION
## Summary
- Keep the iOS audio input graph alive when all send streams are muted.
- Prevent muting from stopping ADM recording, which recreated the AVAudioEngine as output-only and reduced playback loudness.
- Add an AudioState regression test covering mute changes without recording teardown.

## Test plan
- `git diff --check`
- `bundle exec fastlane ios build verbose:true zip_product_skip:true root:/Users/ipavlidakis/workspace/webrtc/src build_root:/Users/ipavlidakis/workspace/webrtc/src configure_google_client_skip:true skip_licenses:true maccatalyst_support:false sign_product_skip:true verify_signatures_skip:true`