### PR TITLE
Upgrade to m145

### DIFF
--- a/.github/actions/prepare-android/action.yml
+++ b/.github/actions/prepare-android/action.yml
@@ -21,10 +21,27 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Preserve local action metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${RUNNER_TEMP}/local-actions"
+        cp -R "${GITHUB_WORKSPACE}/.github/actions/prepare-android" \
+          "${RUNNER_TEMP}/local-actions/prepare-android"
+
     - name: Check out this repository (WebRTC tree)
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.webrtc_ref }}
+
+    - name: Restore local action metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${GITHUB_WORKSPACE}/.github/actions"
+        rm -rf "${GITHUB_WORKSPACE}/.github/actions/prepare-android"
+        cp -R "${RUNNER_TEMP}/local-actions/prepare-android" \
+          "${GITHUB_WORKSPACE}/.github/actions/prepare-android"
 
     - name: Check out stream-webrtc-release-pipeline
       uses: actions/checkout@v4

--- a/.github/actions/prepare-apple/action.yml
+++ b/.github/actions/prepare-apple/action.yml
@@ -21,10 +21,27 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Preserve local action metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${RUNNER_TEMP}/local-actions"
+        cp -R "${GITHUB_WORKSPACE}/.github/actions/prepare-apple" \
+          "${RUNNER_TEMP}/local-actions/prepare-apple"
+
     - name: Check out this repository (WebRTC tree)
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.webrtc_ref }}
+
+    - name: Restore local action metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${GITHUB_WORKSPACE}/.github/actions"
+        rm -rf "${GITHUB_WORKSPACE}/.github/actions/prepare-apple"
+        cp -R "${RUNNER_TEMP}/local-actions/prepare-apple" \
+          "${GITHUB_WORKSPACE}/.github/actions/prepare-apple"
 
     - name: Check out stream-webrtc-release-pipeline
       uses: actions/checkout@v4

--- a/.github/workflows/manual-platform-tests.yml
+++ b/.github/workflows/manual-platform-tests.yml
@@ -1,5 +1,5 @@
-# Manual WebRTC platform tests. Shared planning runs first, host-specific
-# prepare jobs produce platform-ready trees, then platform jobs fan out.
+# Manual WebRTC build. Shared planning runs first, host-specific prepare jobs
+# produce platform-ready trees, then selected platform builds/tests fan out.
 
 name: Build
 
@@ -13,32 +13,68 @@ on:
         description: Branch, tag, or SHA for this repo (GetStream/webrtc)
         required: true
         default: main
-      platform_ios:
-        description: Run iOS simulator tests
+      apple:
+        description: Build and package Apple xcframework artifacts
         type: boolean
         default: true
-      platform_macos:
-        description: Run macOS host tests
+      android:
+        description: Build and package Android AAR artifact
         type: boolean
-        default: false
-      platform_android:
-        description: Run Android AAR build validation
+        default: true
+      debug:
+        description: Build WebRTC artifacts with GN is_debug=true and include Apple dSYMs when available
+        type: boolean
+        default: true
+      run_ios_tests:
+        description: Run iOS simulator tests when Apple is enabled
+        type: boolean
+        default: true
+      run_macos_tests:
+        description: Run macOS host tests when Apple is enabled
         type: boolean
         default: false
       ignore_cache:
         description: Skip restoring dependency caches and force a fresh sync
         type: boolean
-        default: true
+        default: false
+      android_arch:
+        description: Optional Android ABI to build, for example arm64-v8a. Leave empty to build the default ABI set.
+        required: false
+        default: ""
 
 jobs:
+  # Fail invalid manual input before any expensive WebRTC sync/build work starts.
+  validate_inputs:
+    name: Validate build inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure at least one platform is selected
+        env:
+          BUILD_APPLE: ${{ inputs.apple }}
+          BUILD_ANDROID: ${{ inputs.android }}
+        run: |
+          set -euo pipefail
+          if [[ "${BUILD_APPLE}" != "true" && "${BUILD_ANDROID}" != "true" ]]; then
+            echo "At least one of apple or android must be true."
+            exit 1
+          fi
+
+      - name: Validate Android build options
+        env:
+          ANDROID_ARCH: ${{ inputs.android_arch }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${ANDROID_ARCH}" && "${ANDROID_ARCH}" =~ [[:space:]] ]]; then
+            echo "::error::android_arch accepts a single ABI, for example arm64-v8a."
+            exit 1
+          fi
+
   prepare_common:
-    name: Plan platform validation
+    name: Plan platform build
+    needs: validate_inputs
     runs-on: ubuntu-latest
     outputs:
-      run_ios: ${{ steps.plan.outputs.run_ios }}
-      run_macos: ${{ steps.plan.outputs.run_macos }}
-      run_android: ${{ steps.plan.outputs.run_android }}
-      run_apple: ${{ steps.plan.outputs.run_apple }}
       apple_target_os: ${{ steps.plan.outputs.apple_target_os }}
       apple_target_os_cache_key: ${{ steps.plan.outputs.apple_target_os_cache_key }}
       android_target_os: ${{ steps.plan.outputs.android_target_os }}
@@ -48,17 +84,18 @@ jobs:
         uses: actions/checkout@v4
 
       - id: plan
-        name: Plan platform validation
+        name: Plan platform build
         uses: ./.github/actions/prepare-common
         with:
-          platform_ios: ${{ inputs.platform_ios }}
-          platform_macos: ${{ inputs.platform_macos }}
-          platform_android: ${{ inputs.platform_android }}
+          # Apple artifacts include both iOS and macOS slices, so both platform flags follow apple.
+          platform_ios: ${{ inputs.apple }}
+          platform_macos: ${{ inputs.apple }}
+          platform_android: ${{ inputs.android }}
 
   prepare_apple:
     name: Prepare Apple dependencies
     needs: prepare_common
-    if: needs.prepare_common.outputs.run_apple == 'true'
+    if: ${{ inputs.apple }}
     runs-on: macos-26
     timeout-minutes: 360
     steps:
@@ -77,7 +114,7 @@ jobs:
   prepare_android:
     name: Prepare Android dependencies
     needs: prepare_common
-    if: needs.prepare_common.outputs.run_android == 'true'
+    if: ${{ inputs.android }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -95,8 +132,8 @@ jobs:
 
   ios_test:
     name: Validate iOS simulator tests
-    needs: [prepare_common, prepare_apple]
-    if: needs.prepare_common.outputs.run_ios == 'true'
+    needs: prepare_apple
+    if: ${{ inputs.apple && inputs.run_ios_tests }}
     runs-on: macos-26
     timeout-minutes: 180
     steps:
@@ -179,8 +216,8 @@ jobs:
 
   macos_test:
     name: Validate macOS host tests
-    needs: [prepare_common, prepare_apple]
-    if: needs.prepare_common.outputs.run_macos == 'true'
+    needs: prepare_apple
+    if: ${{ inputs.apple && inputs.run_macos_tests }}
     runs-on: macos-26
     timeout-minutes: 180
     steps:
@@ -228,12 +265,12 @@ jobs:
           bundle exec fastlane macos test
           "root:${{ github.workspace }}/webrtc-tree/.output/src"
 
-  android_test:
-    name: Validate Android build
-    needs: [prepare_common, prepare_android]
-    if: needs.prepare_common.outputs.run_android == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
+  build_ios:
+    name: Build iOS SDK
+    needs: prepare_apple
+    if: ${{ inputs.apple }}
+    runs-on: macos-26
+    timeout-minutes: 360
     steps:
       - name: Check out stream-webrtc-release-pipeline
         uses: actions/checkout@v4
@@ -242,7 +279,204 @@ jobs:
           path: release-pipeline
           token: ${{ secrets.RELEASE_PIPELINE_TOKEN || github.token }}
 
-      - name: Download prepared WebRTC tree
+      - name: Download prepared Apple WebRTC tree
+        uses: actions/download-artifact@v4
+        with:
+          name: webrtc-src-prepared-apple
+
+      - name: Extract WebRTC tree
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ github.workspace }}/webrtc-tree"
+          tar -xzf webrtc-src-prepared-apple.tar.gz -C "${{ github.workspace }}/webrtc-tree"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          working-directory: release-pipeline
+          bundler-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install depot_tools
+        run: |
+          if [[ ! -d "${HOME}/depot_tools" ]]; then
+            git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "${HOME}/depot_tools"
+          fi
+          echo "PATH=${HOME}/depot_tools:${PATH}" >> "${GITHUB_ENV}"
+          echo "DEPOT_TOOLS_UPDATE=0" >> "${GITHUB_ENV}"
+
+      - name: Build iOS SDK artifact
+        working-directory: release-pipeline
+        run: >-
+          bundle exec fastlane ios build
+          "root:${{ github.workspace }}/webrtc-tree/.output/src"
+          "build_root:${{ github.workspace }}/webrtc-tree/.output"
+          "products_root:${{ github.workspace }}/ios-products"
+          configure_google_client_skip:true
+          prepare_signing_skip:false
+          sign_product_skip:true
+          verify_signatures_skip:true
+          zip_product_skip:true
+          "build_product_arg_is_debug:${{ inputs.debug }}"
+          build_product_arg_treat_warnings_as_errors:false
+          build_product_arg_rtc_build_examples:false
+          skip_licenses:true
+
+      - name: Package iOS XCFramework artifact
+        run: |
+          set -euo pipefail
+          ditto -c -k --sequesterRsrc --keepParent \
+            "${{ github.workspace }}/ios-products/WebRTC.xcframework" \
+            "${{ github.workspace }}/WebRTC-ios.xcframework.zip"
+
+      - name: Upload iOS SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple-ios-xcframework
+          path: WebRTC-ios.xcframework.zip
+          retention-days: 2
+
+  build_macos:
+    name: Build macOS SDK
+    needs: prepare_apple
+    if: ${{ inputs.apple }}
+    runs-on: macos-26
+    timeout-minutes: 360
+    steps:
+      - name: Check out stream-webrtc-release-pipeline
+        uses: actions/checkout@v4
+        with:
+          repository: GetStream/stream-webrtc-release-pipeline
+          path: release-pipeline
+          token: ${{ secrets.RELEASE_PIPELINE_TOKEN || github.token }}
+
+      - name: Download prepared Apple WebRTC tree
+        uses: actions/download-artifact@v4
+        with:
+          name: webrtc-src-prepared-apple
+
+      - name: Extract WebRTC tree
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ github.workspace }}/webrtc-tree"
+          tar -xzf webrtc-src-prepared-apple.tar.gz -C "${{ github.workspace }}/webrtc-tree"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          working-directory: release-pipeline
+          bundler-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install depot_tools
+        run: |
+          if [[ ! -d "${HOME}/depot_tools" ]]; then
+            git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "${HOME}/depot_tools"
+          fi
+          echo "PATH=${HOME}/depot_tools:${PATH}" >> "${GITHUB_ENV}"
+          echo "DEPOT_TOOLS_UPDATE=0" >> "${GITHUB_ENV}"
+
+      - name: Build macOS SDK artifact
+        working-directory: release-pipeline
+        run: >-
+          bundle exec fastlane macos build
+          "root:${{ github.workspace }}/webrtc-tree/.output/src"
+          "products_root:${{ github.workspace }}/macos-products"
+          "build_product_arg_is_debug:${{ inputs.debug }}"
+          build_product_arg_treat_warnings_as_errors:false
+          build_product_arg_rtc_build_examples:false
+          zip_product_skip:true
+
+      - name: Package macOS XCFramework artifact
+        run: |
+          set -euo pipefail
+          ditto -c -k --sequesterRsrc --keepParent \
+            "${{ github.workspace }}/macos-products/WebRTC.xcframework" \
+            "${{ github.workspace }}/WebRTC-macos.xcframework.zip"
+
+      - name: Upload macOS SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple-macos-xcframework
+          path: WebRTC-macos.xcframework.zip
+          retention-days: 2
+
+  package_apple:
+    name: Package Apple build artifact
+    needs: [build_ios, build_macos, ios_test, macos_test]
+    # Test jobs can be skipped by input. Continue when selected Apple build jobs succeeded and no selected test failed.
+    if: ${{ inputs.apple && !cancelled() && !failure() }}
+    runs-on: macos-26
+    timeout-minutes: 60
+    steps:
+      - name: Download iOS SDK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: apple-ios-xcframework
+          path: apple-inputs/ios
+
+      - name: Download macOS SDK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: apple-macos-xcframework
+          path: apple-inputs/macos
+
+      - name: Combine Apple XCFrameworks
+        env:
+          ENABLE_DEBUG: ${{ inputs.debug }}
+        run: |
+          set -euo pipefail
+          ditto -x -k apple-inputs/ios/WebRTC-ios.xcframework.zip apple-inputs/ios
+          ditto -x -k apple-inputs/macos/WebRTC-macos.xcframework.zip apple-inputs/macos
+
+          command=(xcodebuild -create-xcframework)
+          while IFS= read -r framework; do
+            command+=(-framework "${framework}")
+            if [[ "${ENABLE_DEBUG}" == "true" ]]; then
+              mapfile -t dsyms < <(find "$(dirname "${framework}")" -name "$(basename "${framework}").dSYM" -type d | sort)
+              if [[ "${#dsyms[@]}" -eq 0 ]]; then
+                echo "::warning::Missing dSYM for ${framework}"
+                continue
+              fi
+              command+=(-debug-symbols "${dsyms[0]}")
+            fi
+          done < <(find apple-inputs -name '*.framework' -type d | sort)
+
+          "${command[@]}" -output WebRTC.xcframework
+          ditto -c -k --sequesterRsrc --keepParent WebRTC.xcframework WebRTC.xcframework.zip
+
+      - name: Upload Apple build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apple
+          path: WebRTC.xcframework.zip
+          retention-days: 7
+
+  build_android:
+    name: Build Android AAR
+    needs: prepare_android
+    if: ${{ inputs.android }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Check out stream-webrtc-release-pipeline
+        uses: actions/checkout@v4
+        with:
+          repository: GetStream/stream-webrtc-release-pipeline
+          path: release-pipeline
+          token: ${{ secrets.RELEASE_PIPELINE_TOKEN || github.token }}
+
+      - name: Download prepared Android WebRTC tree
         uses: actions/download-artifact@v4
         with:
           name: webrtc-src-prepared-android
@@ -278,8 +512,31 @@ jobs:
           echo "PATH=${HOME}/depot_tools:${PATH}" >> "${GITHUB_ENV}"
           echo "DEPOT_TOOLS_UPDATE=0" >> "${GITHUB_ENV}"
 
-      - name: Build Android AAR (no gclient sync in lane)
+      - name: Build Android SDK artifact
         working-directory: release-pipeline
-        run: >-
-          bundle exec fastlane android test
-          "root:${{ github.workspace }}/webrtc-tree/.output/src"
+        env:
+          ANDROID_ARCH: ${{ inputs.android_arch }}
+        run: |
+          set -euo pipefail
+
+          fastlane_args=(
+            android build
+            "root:${{ github.workspace }}/webrtc-tree/.output/src"
+            "products_root:${{ github.workspace }}/android-products"
+            "build_product_arg_is_debug:${{ inputs.debug }}"
+            build_product_arg_treat_warnings_as_errors:false
+            build_product_arg_rtc_build_examples:false
+          )
+
+          if [[ -n "${ANDROID_ARCH}" ]]; then
+            fastlane_args+=("archs:${ANDROID_ARCH}")
+          fi
+
+          bundle exec fastlane "${fastlane_args[@]}"
+
+      - name: Upload Android build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-android
+          path: android-products/libwebrtc.aar
+          retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,18 +17,47 @@ on:
         description: Mark the GitHub release as an alpha/pre-release
         type: boolean
         default: false
-      changelog_file:
-        description: Optional changelog file path from the selected branch to attach
+      debug:
+        description: Build WebRTC artifacts with GN is_debug=true
+        type: boolean
+        default: false
+      ios:
+        description: Build, validate, publish Apple artifacts and trigger stream-video-swift-webrtc
+        type: boolean
+        default: true
+      android:
+        description: Build, validate, publish Android artifacts and trigger stream-video-android-webrtc
+        type: boolean
+        default: true
+      changelog:
+        description: Optional release notes markdown. Leave empty to use generated notes.
         required: false
         default: ""
       ignore_cache:
         description: Skip restoring dependency caches and force a fresh sync
         type: boolean
-        default: true
+        default: false
 
 jobs:
+  # Keep this as a separate first job so invalid manual input fails before any expensive WebRTC sync/build work starts.
+  validate_inputs:
+    name: Validate release inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure at least one platform is selected
+        env:
+          BUILD_IOS: ${{ inputs.ios }}
+          BUILD_ANDROID: ${{ inputs.android }}
+        run: |
+          set -euo pipefail
+          if [[ "${BUILD_IOS}" != "true" && "${BUILD_ANDROID}" != "true" ]]; then
+            echo "At least one of ios or android must be true."
+            exit 1
+          fi
+
   plan:
     name: Plan release build
+    needs: validate_inputs
     runs-on: ubuntu-latest
     outputs:
       apple_target_os: ${{ steps.plan.outputs.apple_target_os }}
@@ -43,13 +72,16 @@ jobs:
         name: Plan release build
         uses: ./.github/actions/prepare-common
         with:
-          platform_ios: true
-          platform_macos: true
-          platform_android: true
+          # Platform inputs control which prepare/build/test legs run. iOS releases need both iOS and macOS
+          # Apple artifacts, so platform_macos follows the iOS input.
+          platform_ios: ${{ inputs.ios }}
+          platform_macos: ${{ inputs.ios }}
+          platform_android: ${{ inputs.android }}
 
   prepare_apple:
     name: Prepare Apple dependencies
     needs: plan
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 360
     steps:
@@ -68,6 +100,7 @@ jobs:
   prepare_android:
     name: Prepare Android dependencies
     needs: plan
+    if: ${{ inputs.android }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -86,6 +119,7 @@ jobs:
   validate_ios:
     name: Validate iOS simulator tests
     needs: prepare_apple
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 180
     steps:
@@ -163,6 +197,7 @@ jobs:
   validate_macos:
     name: Validate macOS host tests
     needs: prepare_apple
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 180
     steps:
@@ -213,6 +248,7 @@ jobs:
   build_ios:
     name: Build iOS SDK
     needs: prepare_apple
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 360
     steps:
@@ -259,12 +295,14 @@ jobs:
         run: >-
           bundle exec fastlane ios build
           "root:${{ github.workspace }}/webrtc-tree/.output/src"
+          "build_root:${{ github.workspace }}/webrtc-tree/.output"
           "products_root:${{ github.workspace }}/ios-products"
           configure_google_client_skip:true
           prepare_signing_skip:false
           sign_product_skip:true
           verify_signatures_skip:true
           zip_product_skip:true
+          "build_product_arg_is_debug:${{ inputs.debug }}"
           skip_licenses:true
 
       - name: Package iOS XCFramework artifact
@@ -284,6 +322,7 @@ jobs:
   build_macos:
     name: Build macOS SDK
     needs: prepare_apple
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 360
     steps:
@@ -331,6 +370,7 @@ jobs:
           bundle exec fastlane macos build
           "root:${{ github.workspace }}/webrtc-tree/.output/src"
           "products_root:${{ github.workspace }}/macos-products"
+          "build_product_arg_is_debug:${{ inputs.debug }}"
           zip_product_skip:true
 
       - name: Package macOS XCFramework artifact
@@ -350,6 +390,7 @@ jobs:
   package_apple:
     name: Package Apple release artifact
     needs: [build_ios, build_macos, validate_ios, validate_macos]
+    if: ${{ inputs.ios }}
     runs-on: macos-26
     timeout-minutes: 60
     steps:
@@ -366,6 +407,8 @@ jobs:
           path: apple-inputs/macos
 
       - name: Combine Apple XCFrameworks
+        env:
+          ENABLE_DEBUG: ${{ inputs.debug }}
         run: |
           set -euo pipefail
           ditto -x -k apple-inputs/ios/WebRTC-ios.xcframework.zip apple-inputs/ios
@@ -374,6 +417,14 @@ jobs:
           command=(xcodebuild -create-xcframework)
           while IFS= read -r framework; do
             command+=(-framework "${framework}")
+            if [[ "${ENABLE_DEBUG}" == "true" ]]; then
+              mapfile -t dsyms < <(find "$(dirname "${framework}")" -name "$(basename "${framework}").dSYM" -type d | sort)
+              if [[ "${#dsyms[@]}" -eq 0 ]]; then
+                echo "::warning::Missing dSYM for ${framework}"
+                continue
+              fi
+              command+=(-debug-symbols "${dsyms[0]}")
+            fi
           done < <(find apple-inputs -name '*.framework' -type d | sort)
 
           "${command[@]}" -output WebRTC.xcframework
@@ -389,6 +440,7 @@ jobs:
   build_android:
     name: Build Android AAR
     needs: prepare_android
+    if: ${{ inputs.android }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
@@ -441,6 +493,7 @@ jobs:
           bundle exec fastlane android build
           "root:${{ github.workspace }}/webrtc-tree/.output/src"
           "products_root:${{ github.workspace }}/android-products"
+          "build_product_arg_is_debug:${{ inputs.debug }}"
 
       - name: Upload Android SDK artifact
         uses: actions/upload-artifact@v4
@@ -451,7 +504,10 @@ jobs:
 
   publish:
     name: Publish GitHub release
+    # GitHub Actions needs are static. Jobs for disabled platforms are skipped quickly, and this condition
+    # lets publish continue as long as no selected platform failed or was cancelled.
     needs: [validate_ios, validate_macos, package_apple, build_android]
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out release branch
@@ -466,29 +522,29 @@ jobs:
           merge-multiple: true
           path: release-assets
 
-      - name: Stage optional changelog
-        if: ${{ inputs.changelog_file != '' }}
-        run: |
-          set -euo pipefail
-          changelog="${{ inputs.changelog_file }}"
-          test -f "${changelog}"
-          cp "${changelog}" "release-assets/$(basename "${changelog}")"
-
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ inputs.version }}
           RELEASE_BRANCH: ${{ inputs.branch }}
           IS_ALPHA: ${{ inputs.alpha }}
+          CHANGELOG: ${{ inputs.changelog }}
         run: |
           set -euo pipefail
+          notes_file="$(mktemp)"
+          if [[ -n "${CHANGELOG}" ]]; then
+            printf '%s\n' "${CHANGELOG}" > "${notes_file}"
+          else
+            printf 'Automated WebRTC SDK release %s.\n' "${RELEASE_VERSION}" > "${notes_file}"
+          fi
+
           release_args=(
             "${RELEASE_VERSION}"
             release-assets/*
             --repo "${{ github.repository }}"
             --target "${RELEASE_BRANCH}"
             --title "${RELEASE_VERSION}"
-            --notes "Automated WebRTC SDK release ${RELEASE_VERSION}."
+            --notes-file "${notes_file}"
           )
           if [[ "${IS_ALPHA}" == "true" ]]; then
             release_args+=(--prerelease)
@@ -496,3 +552,39 @@ jobs:
             release_args+=(--latest)
           fi
           gh release create "${release_args[@]}"
+
+  trigger_downstream_releases:
+    name: Trigger downstream WebRTC releases
+    needs: publish
+    if: ${{ !cancelled() && !failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger stream-video-swift-webrtc release
+        # Only trigger the Swift wrapper when Apple artifacts were part of this WebRTC release.
+        if: ${{ inputs.ios }}
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TRIGGER_RELEASE_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          IS_ALPHA: ${{ inputs.alpha }}
+        run: |
+          set -euo pipefail
+          webrtc_release_url="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_VERSION}"
+          gh workflow run publish-from-webrtc.yml \
+            --repo GetStream/stream-video-swift-webrtc \
+            --field "webrtc_release_url=${webrtc_release_url}" \
+            --field "pre_release=${IS_ALPHA}"
+
+      - name: Trigger stream-video-android-webrtc release
+        # Only trigger the Android wrapper when Android artifacts were part of this WebRTC release.
+        if: ${{ inputs.android }}
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TRIGGER_RELEASE_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          IS_ALPHA: ${{ inputs.alpha }}
+        run: |
+          set -euo pipefail
+          webrtc_release_url="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_VERSION}"
+          gh workflow run publish-from-webrtc.yml \
+            --repo GetStream/stream-video-android-webrtc \
+            --field "webrtc_release_url=${webrtc_release_url}" \
+            --field "pre_release=${IS_ALPHA}"

--- a/api/crypto/frame_crypto_transformer.cc
+++ b/api/crypto/frame_crypto_transformer.cc
@@ -442,17 +442,18 @@ void FrameCryptorTransformer::encryptFrame(
   auto key_set = key_handler->GetKeySet(key_index_);
   uint8_t unencrypted_bytes = get_unencrypted_bytes(frame.get(), type_);
 
-  Buffer frame_header(unencrypted_bytes);
+  Buffer frame_header = Buffer::CreateUninitializedWithSize(unencrypted_bytes);
   for (size_t i = 0; i < unencrypted_bytes; i++) {
     frame_header[i] = data_in[i];
   }
 
-  Buffer frame_trailer(2);
+  Buffer frame_trailer = Buffer::CreateUninitializedWithSize(2);
   frame_trailer[0] = getIvSize();
   frame_trailer[1] = key_index_;
   Buffer iv = makeIv(frame->GetSsrc(), frame->GetTimestamp());
 
-  Buffer payload(data_in.size() - unencrypted_bytes);
+  Buffer payload =
+      Buffer::CreateUninitializedWithSize(data_in.size() - unencrypted_bytes);
   for (size_t i = unencrypted_bytes; i < data_in.size(); i++) {
     payload[i - unencrypted_bytes] = data_in[i];
   }
@@ -462,8 +463,7 @@ void FrameCryptorTransformer::encryptFrame(
                         key_set->encryption_key, iv, frame_header, payload,
                         &buffer) == Success) {
     Buffer encrypted_payload(buffer.data(), buffer.size());
-    Buffer tag(encrypted_payload.data() + encrypted_payload.size() - 16,
-                    16);
+    Buffer tag(encrypted_payload.data() + encrypted_payload.size() - 16, 16);
     Buffer data_without_header;
     data_without_header.AppendData(encrypted_payload);
     data_without_header.AppendData(iv);
@@ -566,12 +566,12 @@ void FrameCryptorTransformer::decryptFrame(
 
   uint8_t unencrypted_bytes = get_unencrypted_bytes(frame.get(), type_);
 
-  Buffer frame_header(unencrypted_bytes);
+  Buffer frame_header = Buffer::CreateUninitializedWithSize(unencrypted_bytes);
   for (size_t i = 0; i < unencrypted_bytes; i++) {
     frame_header[i] = data_in[i];
   }
 
-  Buffer frame_trailer(2);
+  Buffer frame_trailer = Buffer::CreateUninitializedWithSize(2);
   frame_trailer[0] = data_in[data_in.size() - 2];
   frame_trailer[1] = data_in[data_in.size() - 1];
   uint8_t ivLength = frame_trailer[0];
@@ -613,12 +613,13 @@ void FrameCryptorTransformer::decryptFrame(
 
   auto key_set = key_handler->GetKeySet(key_index);
 
-  Buffer iv = Buffer(ivLength);
+  Buffer iv = Buffer::CreateUninitializedWithSize(ivLength);
   for (size_t i = 0; i < ivLength; i++) {
     iv[i] = data_in[data_in.size() - 2 - ivLength + i];
   }
 
-  Buffer encrypted_buffer(data_in.size() - unencrypted_bytes);
+  Buffer encrypted_buffer =
+      Buffer::CreateUninitializedWithSize(data_in.size() - unencrypted_bytes);
   for (size_t i = unencrypted_bytes; i < data_in.size(); i++) {
     encrypted_buffer[i - unencrypted_bytes] = data_in[i];
   }
@@ -634,7 +635,8 @@ void FrameCryptorTransformer::decryptFrame(
         H265::ParseRbsp(encrypted_buffer.data(), encrypted_buffer.size()));
   }
 
-  Buffer encrypted_payload(encrypted_buffer.size() - ivLength - 2);
+  Buffer encrypted_payload = Buffer::CreateUninitializedWithSize(
+      encrypted_buffer.size() - ivLength - 2);
   for (size_t i = 0; i < encrypted_payload.size(); i++) {
     encrypted_payload[i] = encrypted_buffer[i];
   }
@@ -795,7 +797,8 @@ RTCErrorOr<webrtc::scoped_refptr<EncryptedPacket>> DataPacketCryptor::Encrypt(
 
   std::vector<uint8_t> buffer;
   Buffer payload(data.data(), data.size());
-  auto frame_header = Buffer(0);  // no frame header for data packets
+  auto frame_header = Buffer::CreateUninitializedWithSize(
+      0);  // no frame header for data packets
   if (AesEncryptDecrypt(EncryptOrDecrypt::kEncrypt, algorithm_,
                         key_set->encryption_key, iv, frame_header, payload,
                         &buffer) == Success) {
@@ -826,12 +829,13 @@ RTCErrorOr<std::vector<uint8_t>> DataPacketCryptor::Decrypt(
                         std::to_string(key_index) +
                         "] out of range for participant " + participant_id);
   }
-  
+
   std::vector<uint8_t> buffer;
   Buffer encrypted_payload(encryptedPacket->data.data(),
-                                encryptedPacket->data.size());
+                           encryptedPacket->data.size());
   Buffer iv(encryptedPacket->iv.data(), encryptedPacket->iv.size());
-  auto frame_header = Buffer(0);  // no frame header for data packets
+  auto frame_header = Buffer::CreateUninitializedWithSize(
+      0);  // no frame header for data packets
 
   auto key_set = key_handler->GetKeySet(key_index);
   auto initialKeyMaterial = key_set->material;

--- a/api/test/mock_transformable_video_frame.h
+++ b/api/test/mock_transformable_video_frame.h
@@ -45,7 +45,6 @@ class MockTransformableVideoFrame : public TransformableVideoFrameInterface {
               (const, override));
   MOCK_METHOD(std::string, GetMimeType, (), (const, override));
   MOCK_METHOD(VideoFrameMetadata, Metadata, (), (const, override));
-  MOCK_METHOD(RTPVideoHeader&, header, (), (const, override));
   MOCK_METHOD(std::optional<Timestamp>,
               GetPresentationTimestamp,
               (),

--- a/audio/audio_state.cc
+++ b/audio/audio_state.cc
@@ -184,9 +184,10 @@ void AudioState::OnMuteStreamChanged() {
     if (!adm->Recording() && adm->InitRecording() == 0) {
       adm->StartRecording();
     }
-  } else {
-    adm->StopRecording();
   }
+  // Do not stop recording when all send streams are muted. On iOS, tearing
+  // down input recreates the audio graph as output-only and changes playout
+  // loudness; explicit SetRecording(false) and stream removal still stop input.
 }
 
 void AudioState::UpdateAudioTransportWithSendingStreams() {

--- a/audio/audio_state_unittest.cc
+++ b/audio/audio_state_unittest.cc
@@ -52,6 +52,7 @@ using ::testing::InSequence;
 using ::testing::Matcher;
 using ::testing::NiceMock;
 using ::testing::NotNull;
+using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::Values;
 
@@ -445,6 +446,29 @@ TEST_P(AudioStateTest, AlwaysCallInitRecordingBeforeStartRecording) {
     audio_state->SetRecording(true);
   }
 
+  EXPECT_CALL(*adm, StopRecording());
+  audio_state->RemoveSendingStream(&stream);
+}
+
+TEST_P(AudioStateTest, MuteStreamChangeDoesNotStopRecording) {
+  ConfigHelper helper(GetParam());
+  scoped_refptr<internal::AudioState> audio_state(
+      make_ref_counted<internal::AudioState>(helper.config()));
+
+  auto* adm = reinterpret_cast<MockAudioDeviceModule*>(
+      helper.config().audio_device_module.get());
+
+  MockAudioSendStream stream;
+  EXPECT_CALL(*adm, InitRecording());
+  EXPECT_CALL(*adm, StartRecording());
+  audio_state->AddSendingStream(&stream, kSampleRate, kNumberOfChannels);
+
+  EXPECT_CALL(stream, GetMuted()).WillRepeatedly(Return(true));
+  EXPECT_CALL(*adm, StopRecording()).Times(0);
+  audio_state->OnMuteStreamChanged();
+
+  testing::Mock::VerifyAndClearExpectations(&stream);
+  testing::Mock::VerifyAndClearExpectations(adm);
   EXPECT_CALL(*adm, StopRecording());
   audio_state->RemoveSendingStream(&stream);
 }

--- a/media/engine/simulcast_encoder_adapter.cc
+++ b/media/engine/simulcast_encoder_adapter.cc
@@ -1007,6 +1007,12 @@ VideoEncoder::EncoderInfo SimulcastEncoderAdapter::GetEncoderInfo() const {
 
   encoder_info.scaling_settings = VideoEncoder::ScalingSettings::kOff;
   std::vector<std::string> encoder_names;
+  // SEA can keep multiple stream contexts alive even when runtime bitrate
+  // allocation has paused all but one spatial layer. Track that state
+  // explicitly so we can preserve simulcast-specific aggregation while still
+  // forwarding the active encoder's single-layer adaptation hints.
+  size_t active_stream_count = 0;
+  std::optional<VideoEncoder::EncoderInfo> active_stream_info;
 
   for (size_t i = 0; i < stream_contexts_.size(); ++i) {
     VideoEncoder::EncoderInfo encoder_impl_info =
@@ -1014,6 +1020,11 @@ VideoEncoder::EncoderInfo SimulcastEncoderAdapter::GetEncoderInfo() const {
 
     // Encoder name indicates names of all active sub-encoders.
     if (!stream_contexts_[i].is_paused()) {
+      // If exactly one layer stays unpaused after SetRates(), this is the
+      // encoder whose runtime adaptation fields should be exposed to the rest
+      // of WebRTC.
+      ++active_stream_count;
+      active_stream_info = encoder_impl_info;
       encoder_names.push_back(encoder_impl_info.implementation_name);
     }
 
@@ -1073,6 +1084,27 @@ VideoEncoder::EncoderInfo SimulcastEncoderAdapter::GetEncoderInfo() const {
     implementation_name_builder << StrJoin(encoder_names, ", ");
     implementation_name_builder << ")";
     encoder_info.implementation_name += implementation_name_builder.Release();
+  }
+
+  if (active_stream_count == 1) {
+    RTC_DCHECK(active_stream_info.has_value());
+    // Keep the aggregated SEA view for simulcast-specific fields such as
+    // implementation_name, fps_allocation and alignment, but make the adapter
+    // behave like single-layer publishing for the runtime-sensitive fields
+    // consumed by adaptation and frame handling.
+    encoder_info.scaling_settings = active_stream_info->scaling_settings;
+    encoder_info.supports_native_handle =
+        active_stream_info->supports_native_handle;
+    encoder_info.has_trusted_rate_controller =
+        active_stream_info->has_trusted_rate_controller;
+    encoder_info.is_hardware_accelerated =
+        active_stream_info->is_hardware_accelerated;
+    encoder_info.is_qp_trusted = active_stream_info->is_qp_trusted;
+    encoder_info.resolution_bitrate_limits =
+        active_stream_info->resolution_bitrate_limits;
+    encoder_info.min_qp = active_stream_info->min_qp;
+    encoder_info.preferred_pixel_formats =
+        active_stream_info->preferred_pixel_formats;
   }
 
   OverrideFromFieldTrial(&encoder_info);

--- a/media/engine/simulcast_encoder_adapter_unittest.cc
+++ b/media/engine/simulcast_encoder_adapter_unittest.cc
@@ -289,6 +289,7 @@ class MockVideoEncoder : public VideoEncoder {
     info.supports_simulcast = supports_simulcast_;
     info.is_qp_trusted = is_qp_trusted_;
     info.resolution_bitrate_limits = resolution_bitrate_limits;
+    info.min_qp = min_qp_;
     return info;
   }
 
@@ -368,6 +369,8 @@ class MockVideoEncoder : public VideoEncoder {
     resolution_bitrate_limits = limits;
   }
 
+  void set_min_qp(std::optional<int> min_qp) { min_qp_ = min_qp; }
+
   bool supports_simulcast() const { return supports_simulcast_; }
 
   SdpVideoFormat video_format() const { return video_format_; }
@@ -387,6 +390,7 @@ class MockVideoEncoder : public VideoEncoder {
   FramerateFractions fps_allocation_;
   bool supports_simulcast_ = false;
   std::optional<bool> is_qp_trusted_;
+  std::optional<int> min_qp_;
   SdpVideoFormat video_format_;
   std::vector<VideoEncoder::ResolutionBitrateLimits> resolution_bitrate_limits;
 
@@ -1714,6 +1718,143 @@ TEST_F(TestSimulcastEncoderAdapterFake, ReportsFpsAllocation) {
   EXPECT_EQ(0, adapter_->InitEncode(&codec_, kSettings));
   EXPECT_THAT(adapter_->GetEncoderInfo().fps_allocation,
               ::testing::ElementsAreArray(expected_fps_allocation));
+}
+
+TEST_F(TestSimulcastEncoderAdapterFake,
+       ForwardsRuntimeSensitiveEncoderInfoForSingleUnpausedLayer) {
+  SimulcastTestFixtureImpl::DefaultSettings(
+      &codec_, static_cast<const int*>(kTestTemporalLayerProfile),
+      kVideoCodecVP8);
+  codec_.numberOfSimulcastStreams = 3;
+  EXPECT_EQ(0, adapter_->InitEncode(&codec_, kSettings));
+  adapter_->RegisterEncodeCompleteCallback(this);
+  ASSERT_EQ(3u, helper_->factory()->encoders().size());
+
+  auto* low_encoder = helper_->factory()->encoders()[0];
+  auto* mid_encoder = helper_->factory()->encoders()[1];
+  auto* high_encoder = helper_->factory()->encoders()[2];
+
+  low_encoder->set_scaling_settings(VideoEncoder::ScalingSettings(10, 20, 111));
+  low_encoder->set_supports_native_handle(false);
+  low_encoder->set_is_qp_trusted(true);
+  low_encoder->set_resolution_bitrate_limits(
+      {VideoEncoder::ResolutionBitrateLimits(111, 1111, 2222, 3333)});
+  low_encoder->set_min_qp(10);
+  low_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction / 2});
+
+  mid_encoder->set_scaling_settings(VideoEncoder::ScalingSettings(30, 40, 222));
+  mid_encoder->set_supports_native_handle(true);
+  mid_encoder->set_is_qp_trusted(false);
+  mid_encoder->set_resolution_bitrate_limits(
+      {VideoEncoder::ResolutionBitrateLimits(222, 4444, 5555, 6666)});
+  mid_encoder->set_min_qp(20);
+  mid_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction / 3,
+                         EncoderInfo::kMaxFramerateFraction});
+
+  high_encoder->set_scaling_settings(
+      VideoEncoder::ScalingSettings(50, 60, 333));
+  high_encoder->set_supports_native_handle(false);
+  high_encoder->set_is_qp_trusted(true);
+  high_encoder->set_resolution_bitrate_limits(
+      {VideoEncoder::ResolutionBitrateLimits(333, 7777, 8888, 9999)});
+  high_encoder->set_min_qp(30);
+  high_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction});
+
+  // Only keep the middle spatial layer active. SEA still has three stream
+  // contexts, so this exercises the runtime state that used to incorrectly
+  // report aggregated simulcast encoder info with scaling disabled.
+  VideoBitrateAllocation allocation;
+  ASSERT_TRUE(allocation.SetBitrate(1, 0, 500000));
+  adapter_->SetRates(VideoEncoder::RateControlParameters(allocation, 30.0));
+
+  const auto info = adapter_->GetEncoderInfo();
+  // Runtime-sensitive fields should come from the only unpaused encoder.
+  ASSERT_TRUE(info.scaling_settings.thresholds.has_value());
+  EXPECT_EQ(30, info.scaling_settings.thresholds->low);
+  EXPECT_EQ(40, info.scaling_settings.thresholds->high);
+  EXPECT_EQ(222, info.scaling_settings.min_pixels_per_frame);
+  EXPECT_TRUE(info.supports_native_handle);
+  EXPECT_EQ(std::optional<bool>(false), info.is_qp_trusted);
+  EXPECT_EQ(std::optional<int>(20), info.min_qp);
+  EXPECT_EQ(info.resolution_bitrate_limits,
+            std::vector<VideoEncoder::ResolutionBitrateLimits>(
+                {VideoEncoder::ResolutionBitrateLimits(222, 4444, 5555, 6666)}));
+  // Simulcast-specific fields must remain in SEA's aggregated spatial-slot
+  // layout even when runtime-sensitive fields are forwarded from one encoder.
+  EXPECT_THAT(info.fps_allocation[0],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction / 2));
+  EXPECT_THAT(info.fps_allocation[1],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction / 3,
+                                     EncoderInfo::kMaxFramerateFraction));
+  EXPECT_THAT(info.fps_allocation[2],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction));
+}
+
+TEST_F(TestSimulcastEncoderAdapterFake,
+       RestoresAggregatedEncoderInfoWhenMultipleLayersUnpause) {
+  SimulcastTestFixtureImpl::DefaultSettings(
+      &codec_, static_cast<const int*>(kTestTemporalLayerProfile),
+      kVideoCodecVP8);
+  codec_.numberOfSimulcastStreams = 3;
+  EXPECT_EQ(0, adapter_->InitEncode(&codec_, kSettings));
+  adapter_->RegisterEncodeCompleteCallback(this);
+  ASSERT_EQ(3u, helper_->factory()->encoders().size());
+
+  auto* low_encoder = helper_->factory()->encoders()[0];
+  auto* mid_encoder = helper_->factory()->encoders()[1];
+  auto* high_encoder = helper_->factory()->encoders()[2];
+
+  low_encoder->set_scaling_settings(VideoEncoder::ScalingSettings(10, 20, 111));
+  low_encoder->set_supports_native_handle(false);
+  low_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction / 2});
+
+  mid_encoder->set_scaling_settings(VideoEncoder::ScalingSettings(30, 40, 222));
+  mid_encoder->set_supports_native_handle(true);
+  mid_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction / 3,
+                         EncoderInfo::kMaxFramerateFraction});
+
+  high_encoder->set_scaling_settings(
+      VideoEncoder::ScalingSettings(50, 60, 333));
+  high_encoder->set_supports_native_handle(false);
+  high_encoder->set_fps_allocation(
+      FramerateFractions{EncoderInfo::kMaxFramerateFraction});
+
+  // First collapse to a single active spatial layer and verify the forwarded
+  // encoder info.
+  VideoBitrateAllocation one_layer_allocation;
+  ASSERT_TRUE(one_layer_allocation.SetBitrate(1, 0, 500000));
+  adapter_->SetRates(
+      VideoEncoder::RateControlParameters(one_layer_allocation, 30.0));
+
+  auto info = adapter_->GetEncoderInfo();
+  ASSERT_TRUE(info.scaling_settings.thresholds.has_value());
+  EXPECT_EQ(30, info.scaling_settings.thresholds->low);
+  EXPECT_EQ(40, info.scaling_settings.thresholds->high);
+  EXPECT_TRUE(info.supports_native_handle);
+
+  // Then enable another layer. SEA should immediately return to its normal
+  // aggregated simulcast view without requiring a re-init.
+  VideoBitrateAllocation two_layer_allocation;
+  ASSERT_TRUE(two_layer_allocation.SetBitrate(1, 0, 500000));
+  ASSERT_TRUE(two_layer_allocation.SetBitrate(2, 0, 700000));
+  adapter_->SetRates(
+      VideoEncoder::RateControlParameters(two_layer_allocation, 30.0));
+
+  info = adapter_->GetEncoderInfo();
+  EXPECT_FALSE(info.scaling_settings.thresholds.has_value());
+  EXPECT_TRUE(info.supports_native_handle);
+  EXPECT_THAT(info.fps_allocation[0],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction / 2));
+  EXPECT_THAT(info.fps_allocation[1],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction / 3,
+                                     EncoderInfo::kMaxFramerateFraction));
+  EXPECT_THAT(info.fps_allocation[2],
+              ::testing::ElementsAre(EncoderInfo::kMaxFramerateFraction));
 }
 
 TEST_F(TestSimulcastEncoderAdapterFake, SetRateDistributesBandwithAllocation) {

--- a/modules/audio_device/include/test_audio_device.cc
+++ b/modules/audio_device/include/test_audio_device.cc
@@ -51,17 +51,17 @@ constexpr int kFramesPerSecond = kNumMicrosecsPerSec / kFrameLengthUs;
 class TestAudioDeviceModuleImpl : public AudioDeviceModuleImpl {
  public:
   TestAudioDeviceModuleImpl(
-      TaskQueueFactory* task_queue_factory,
+      const Environment& env,
       std::unique_ptr<TestAudioDeviceModule::Capturer> capturer,
       std::unique_ptr<TestAudioDeviceModule::Renderer> renderer,
       float speed = 1)
       : AudioDeviceModuleImpl(
             AudioLayer::kDummyAudio,
-            std::make_unique<TestAudioDevice>(task_queue_factory,
+            std::make_unique<TestAudioDevice>(env,
                                               std::move(capturer),
                                               std::move(renderer),
                                               speed),
-            task_queue_factory,
+            &env.task_queue_factory(),
             /*create_detached=*/true) {}
 
   ~TestAudioDeviceModuleImpl() override = default;
@@ -70,16 +70,16 @@ class TestAudioDeviceModuleImpl : public AudioDeviceModuleImpl {
 class TestAudioDeviceModuleImpl : public AudioDeviceModuleForTest {
  public:
   TestAudioDeviceModuleImpl(
-      TaskQueueFactory* task_queue_factory,
+      const Environment& env,
       std::unique_ptr<TestAudioDeviceModule::Capturer> capturer,
       std::unique_ptr<TestAudioDeviceModule::Renderer> renderer,
       float speed = 1)
       : audio_device_(std::make_unique<TestAudioDevice>(
-            task_queue_factory,
+            env,
             std::move(capturer),
             std::move(renderer),
             speed)),
-        audio_device_buffer_(task_queue_factory,
+        audio_device_buffer_(&env.task_queue_factory(),
                              /*create_detached=*/true) {
     audio_device_->AttachAudioBuffer(&audio_device_buffer_);
   }
@@ -784,12 +784,12 @@ size_t TestAudioDeviceModule::SamplesPerFrame(int sampling_frequency_in_hz) {
 }
 
 scoped_refptr<AudioDeviceModule> TestAudioDeviceModule::Create(
-    TaskQueueFactory* task_queue_factory,
+    const Environment& env,
     std::unique_ptr<TestAudioDeviceModule::Capturer> capturer,
     std::unique_ptr<TestAudioDeviceModule::Renderer> renderer,
     float speed) {
   auto audio_device = make_ref_counted<TestAudioDeviceModuleImpl>(
-      task_queue_factory, std::move(capturer), std::move(renderer), speed);
+      env, std::move(capturer), std::move(renderer), speed);
 
 #if defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
   // Ensure that the current platform is supported.

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -95,6 +95,7 @@ if (is_ios || is_mac) {
   rtc_library("base_objc") {
     visibility = [ "*" ]
     sources = [
+      "objc/base/RTCAudioRenderer.h",
       "objc/base/RTCCodecSpecificInfo.h",
       "objc/base/RTCEncodedImage.h",
       "objc/base/RTCEncodedImage.m",
@@ -253,7 +254,7 @@ if (is_ios || is_mac) {
   }
 
   if (!build_with_chromium) {
-    if (is_ios) {
+    if (is_ios || is_mac) {
       rtc_library("native_api_audio_device_module") {
         visibility = [ "*" ]
 
@@ -263,7 +264,6 @@ if (is_ios || is_mac) {
         ]
 
         deps = [
-          ":audio_device",
           ":audio_device_module_error_handler",
           "../api:make_ref_counted",
           "../api:scoped_refptr",
@@ -274,8 +274,14 @@ if (is_ios || is_mac) {
           "../rtc_base:logging",
           "../system_wrappers",
         ]
-      }
 
+        if (is_ios) {
+          deps += [ ":audio_device" ]
+        }
+      }
+    }
+
+    if (is_ios) {
       rtc_source_set("audio_session_observer") {
         visibility = [ ":*" ]
 
@@ -681,7 +687,6 @@ if (is_ios || is_mac) {
       if (is_mac) {
         sources += [
           "objc/components/renderer/metal/RTCMTLNSVideoView.h",
-          "objc/components/renderer/metal/RTCMTLNSVideoView.m",
         ]
         frameworks += [ "AppKit.framework" ]
       }
@@ -1094,11 +1099,19 @@ if (is_ios || is_mac) {
         "objc/api/peerconnection/RTCDataChannelConfiguration+Private.h",
         "objc/api/peerconnection/RTCDataChannelConfiguration.h",
         "objc/api/peerconnection/RTCDataChannelConfiguration.mm",
+        "objc/api/peerconnection/RTCDataPacketCryptor.h",
+        "objc/api/peerconnection/RTCDataPacketCryptor.mm",
         "objc/api/peerconnection/RTCDtmfSender+Private.h",
         "objc/api/peerconnection/RTCDtmfSender.h",
         "objc/api/peerconnection/RTCDtmfSender.mm",
         "objc/api/peerconnection/RTCFieldTrials.h",
         "objc/api/peerconnection/RTCFieldTrials.mm",
+        "objc/api/peerconnection/RTCFrameCryptor+Private.h",
+        "objc/api/peerconnection/RTCFrameCryptor.h",
+        "objc/api/peerconnection/RTCFrameCryptor.mm",
+        "objc/api/peerconnection/RTCFrameCryptorKeyProvider+Private.h",
+        "objc/api/peerconnection/RTCFrameCryptorKeyProvider.h",
+        "objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm",
         "objc/api/peerconnection/RTCIODevice.h",
         "objc/api/peerconnection/RTCIODevice.mm",
         "objc/api/peerconnection/RTCIceCandidate+Private.h",
@@ -1257,6 +1270,7 @@ if (is_ios || is_mac) {
         "../api/audio_codecs:audio_codecs_api",
         "../api/audio_codecs:builtin_audio_decoder_factory",
         "../api/audio_codecs:builtin_audio_encoder_factory",
+        "../api/crypto:frame_crypto_transformer",
         "../api/crypto:frame_decryptor_interface",
         "../api/crypto:frame_encryptor_interface",
         "../api/environment",
@@ -1290,10 +1304,9 @@ if (is_ios || is_mac) {
         "../system_wrappers:metrics",
       ]
 
-      if (is_ios) {
+      if (is_ios || is_mac) {
         deps += [
           ":native_api_audio_device_module",
-          "../api/transport:network_control",
         ]
       }
     }
@@ -1448,6 +1461,11 @@ if (is_ios || is_mac) {
       }
     }
 
+    bundle_data("darwin_privacy_info") {
+      sources = [ "objc/PrivacyInfo.xcprivacy" ]
+      outputs = [ "{{bundle_resources_dir}}/{{source_file_part}}" ]
+    }
+
     if (is_ios) {
       apple_framework_bundle_with_umbrella_header("framework_objc") {
         info_plist = "objc/Info.plist"
@@ -1473,6 +1491,7 @@ if (is_ios || is_mac) {
           "objc/base/RTCVideoFrame.h",
           "objc/base/RTCVideoFrameBuffer.h",
           "objc/base/RTCVideoRenderer.h",
+          "objc/base/RTCAudioRenderer.h",
           "objc/base/RTCYUVPlanarBuffer.h",
           "objc/components/audio/RTCAudioDevice.h",
           "objc/components/audio/RTCAudioSession.h",
@@ -1502,6 +1521,9 @@ if (is_ios || is_mac) {
           "objc/api/peerconnection/RTCConfiguration.h",
           "objc/api/peerconnection/RTCDataChannel.h",
           "objc/api/peerconnection/RTCDataChannelConfiguration.h",
+          "objc/api/peerconnection/RTCDataPacketCryptor.h",
+          "objc/api/peerconnection/RTCFrameCryptor.h",
+          "objc/api/peerconnection/RTCFrameCryptorKeyProvider.h",
           "objc/api/peerconnection/RTCFieldTrials.h",
           "objc/api/peerconnection/RTCIceCandidate.h",
           "objc/api/peerconnection/RTCIceCandidateErrorEvent.h",
@@ -1601,6 +1623,7 @@ if (is_ios || is_mac) {
         deps = [
           ":audio_objc",
           ":base_objc",
+          ":darwin_privacy_info",
           ":default_codec_factory_objc",
           ":metal_objc",
           ":native_api",
@@ -1642,6 +1665,39 @@ if (is_ios || is_mac) {
     }
 
     if (is_mac) {
+      rtc_library("desktopcapture_objc") {
+        visibility = [ "*" ]
+        sources = [
+          "objc/components/capturer/RTCDesktopCapturer+Private.h",
+          "objc/components/capturer/RTCDesktopCapturer.h",
+          "objc/components/capturer/RTCDesktopCapturer.mm",
+          "objc/components/capturer/RTCDesktopMediaList+Private.h",
+          "objc/components/capturer/RTCDesktopMediaList.h",
+          "objc/components/capturer/RTCDesktopMediaList.mm",
+          "objc/components/capturer/RTCDesktopSource+Private.h",
+          "objc/components/capturer/RTCDesktopSource.h",
+          "objc/components/capturer/RTCDesktopSource.mm",
+          "objc/native/src/objc_desktop_capture.h",
+          "objc/native/src/objc_desktop_capture.mm",
+          "objc/native/src/objc_desktop_media_list.h",
+          "objc/native/src/objc_desktop_media_list.mm",
+        ]
+        frameworks = [ "AppKit.framework" ]
+
+        configs += [ "..:common_objc" ]
+
+        public_configs = [ ":common_config_objc" ]
+
+        deps = [
+          ":base_objc",
+          ":helpers_objc",
+          ":videoframebuffer_objc",
+          "../modules/desktop_capture",
+          "../rtc_base/system:gcd_helpers",
+          "//third_party:jpeg",
+        ]
+      }
+
       apple_framework_bundle_with_umbrella_header("mac_framework_objc") {
         info_plist = "objc/Info.plist"
         output_name = "WebRTC"
@@ -1655,8 +1711,11 @@ if (is_ios || is_mac) {
           "objc/api/peerconnection/RTCCryptoOptions.h",
           "objc/api/peerconnection/RTCDataChannel.h",
           "objc/api/peerconnection/RTCDataChannelConfiguration.h",
+          "objc/api/peerconnection/RTCDataPacketCryptor.h",
           "objc/api/peerconnection/RTCDtmfSender.h",
           "objc/api/peerconnection/RTCFieldTrials.h",
+          "objc/api/peerconnection/RTCFrameCryptor.h",
+          "objc/api/peerconnection/RTCFrameCryptorKeyProvider.h",
           "objc/api/peerconnection/RTCIODevice.h",
           "objc/api/peerconnection/RTCIceCandidate.h",
           "objc/api/peerconnection/RTCIceCandidateErrorEvent.h",
@@ -1697,6 +1756,7 @@ if (is_ios || is_mac) {
           "objc/api/video_codec/RTCVideoEncoderVP9.h",
           "objc/api/video_frame_buffer/RTCNativeI420Buffer.h",
           "objc/api/video_frame_buffer/RTCNativeMutableI420Buffer.h",
+          "objc/base/RTCAudioRenderer.h",
           "objc/base/RTCCodecSpecificInfo.h",
           "objc/base/RTCEncodedImage.h",
           "objc/base/RTCI420Buffer.h",
@@ -1718,6 +1778,9 @@ if (is_ios || is_mac) {
           "objc/base/RTCVideoRenderer.h",
           "objc/base/RTCYUVPlanarBuffer.h",
           "objc/components/capturer/RTCCameraVideoCapturer.h",
+          "objc/components/capturer/RTCDesktopCapturer.h",
+          "objc/components/capturer/RTCDesktopMediaList.h",
+          "objc/components/capturer/RTCDesktopSource.h",
           "objc/components/capturer/RTCFileVideoCapturer.h",
           "objc/components/renderer/metal/RTCMTLNSVideoView.h",
           "objc/components/renderer/opengl/RTCVideoViewShading.h",
@@ -1741,7 +1804,9 @@ if (is_ios || is_mac) {
 
         deps = [
           ":base_objc",
+          ":darwin_privacy_info",
           ":default_codec_factory_objc",
+          ":desktopcapture_objc",
           ":metal_objc",
           ":native_api",
           ":native_video",

--- a/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptor.mm
@@ -32,8 +32,8 @@
 
 namespace webrtc {
 
-RTCFrameCryptorDelegateAdapter::RTCFrameCryptorDelegateAdapter(RTC_OBJC_TYPE(RTCFrameCryptor) *
-                                                               frameCryptor)
+RTCFrameCryptorDelegateAdapter::RTCFrameCryptorDelegateAdapter(
+    RTC_OBJC_TYPE(RTCFrameCryptor) * frameCryptor)
     : frame_cryptor_(frameCryptor) {}
 
 RTCFrameCryptorDelegateAdapter::~RTCFrameCryptorDelegateAdapter() {}
@@ -46,45 +46,64 @@ RTCFrameCryptorDelegateAdapter::~RTCFrameCryptorDelegateAdapter() {}
   kMissingKey,
   kInternalError,
 */
-void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::string participant_id,
-                                                                 FrameCryptionState state) {
+void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(
+    const std::string participant_id, FrameCryptionState state) {
   RTC_OBJC_TYPE(RTCFrameCryptor) *frameCryptor = frame_cryptor_;
   if (frameCryptor.delegate) {
     switch (state) {
       case FrameCryptionState::kNew:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateNew)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:RTC_OBJC_TYPE(
+                                                RTCFrameCryptorStateNew)];
         break;
       case FrameCryptionState::kOk:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateOk)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:RTC_OBJC_TYPE(
+                                                RTCFrameCryptorStateOk)];
         break;
       case FrameCryptionState::kEncryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateEncryptionFailed)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:
+                                      RTC_OBJC_TYPE(
+                                          RTCFrameCryptorStateEncryptionFailed)];
         break;
       case FrameCryptionState::kDecryptionFailed:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateDecryptionFailed)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:
+                                      RTC_OBJC_TYPE(
+                                          RTCFrameCryptorStateDecryptionFailed)];
         break;
       case FrameCryptionState::kMissingKey:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateMissingKey)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:
+                                      RTC_OBJC_TYPE(
+                                          RTCFrameCryptorStateMissingKey)];
         break;
       case FrameCryptionState::kKeyRatcheted:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateKeyRatcheted)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:
+                                      RTC_OBJC_TYPE(
+                                          RTCFrameCryptorStateKeyRatcheted)];
         break;
       case FrameCryptionState::kInternalError:
         [frameCryptor.delegate frameCryptor:frameCryptor
-            didStateChangeWithParticipantId:[NSString stringForStdString:participant_id]
-                                  withState:RTC_OBJC_TYPE(RTCFrameCryptorStateInternalError)];
+            didStateChangeWithParticipantId:
+                [NSString stringForStdString:participant_id]
+                                  withState:
+                                      RTC_OBJC_TYPE(
+                                          RTCFrameCryptorStateInternalError)];
         break;
     }
   }
@@ -94,7 +113,8 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 @implementation RTC_OBJC_TYPE (RTCFrameCryptor) {
   const webrtc::RtpSenderInterface *_sender;
   const webrtc::RtpReceiverInterface *_receiver;
-  webrtc::scoped_refptr<webrtc::FrameCryptorTransformer> _frame_crypto_transformer;
+  webrtc::scoped_refptr<webrtc::FrameCryptorTransformer>
+      _frame_crypto_transformer;
   webrtc::scoped_refptr<webrtc::RTCFrameCryptorDelegateAdapter> _observer;
   os_unfair_lock _lock;
 }
@@ -102,7 +122,8 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 @synthesize participantId = _participantId;
 @synthesize delegate = _delegate;
 
-- (webrtc::FrameCryptorTransformer::Algorithm)algorithmFromEnum:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm {
+- (webrtc::FrameCryptorTransformer::Algorithm)algorithmFromEnum:
+    (RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm {
   switch (algorithm) {
     case RTC_OBJC_TYPE(RTCCryptorAlgorithmAesGcm):
       return webrtc::FrameCryptorTransformer::Algorithm::kAesGcm;
@@ -111,82 +132,102 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
   }
 }
 
-- (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
-                               rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
-                           participantId:(NSString *)participantId
-                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
-                             keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
+- (nullable instancetype)
+    initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+          rtpSender:(RTC_OBJC_TYPE(RTCRtpSender) *)sender
+      participantId:(NSString *)participantId
+          algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
+        keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
   self = [super init];
   if (self) {
     _lock = OS_UNFAIR_LOCK_INIT;
 
-    webrtc::scoped_refptr<webrtc::RtpSenderInterface> nativeRtpSender = sender.nativeRtpSender;
+    webrtc::scoped_refptr<webrtc::RtpSenderInterface> nativeRtpSender =
+        sender.nativeRtpSender;
     if (nativeRtpSender == nullptr) return nil;
 
-    webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> nativeTrack = nativeRtpSender->track();
+    webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> nativeTrack =
+        nativeRtpSender->track();
     if (nativeTrack == nullptr) return nil;
 
     webrtc::FrameCryptorTransformer::MediaType mediaType =
-        nativeTrack->kind() == "audio" ? webrtc::FrameCryptorTransformer::MediaType::kAudioFrame
-                                       : webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
+        nativeTrack->kind() == "audio" ?
+        webrtc::FrameCryptorTransformer::MediaType::kAudioFrame :
+        webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
 
     os_unfair_lock_lock(&_lock);
-    _observer = webrtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
+    _observer =
+        webrtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
     _participantId = participantId;
 
     _frame_crypto_transformer =
-        webrtc::scoped_refptr<webrtc::FrameCryptorTransformer>(new webrtc::FrameCryptorTransformer(
-            factory.signalingThread, [participantId stdString], mediaType,
-            [self algorithmFromEnum:algorithm], keyProvider.nativeKeyProvider));
+        webrtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
+            new webrtc::FrameCryptorTransformer(
+                factory.signalingThread,
+                [participantId stdString],
+                mediaType,
+                [self algorithmFromEnum:algorithm],
+                keyProvider.nativeKeyProvider));
 
     factory.signalingThread->BlockingCall([self, nativeRtpSender] {
       // Must be called on signal thread
-      nativeRtpSender->SetEncoderToPacketizerFrameTransformer(_frame_crypto_transformer);
+      nativeRtpSender->SetFrameTransformer(_frame_crypto_transformer);
     });
 
     _frame_crypto_transformer->SetEnabled(false);
-    _frame_crypto_transformer->RegisterFrameCryptorTransformerObserver(_observer);
+    _frame_crypto_transformer->RegisterFrameCryptorTransformerObserver(
+        _observer);
     os_unfair_lock_unlock(&_lock);
   }
 
   return self;
 }
 
-- (nullable instancetype)initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
-                             rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
-                           participantId:(NSString *)participantId
-                               algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
-                             keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
+- (nullable instancetype)
+    initWithFactory:(RTC_OBJC_TYPE(RTCPeerConnectionFactory) *)factory
+        rtpReceiver:(RTC_OBJC_TYPE(RTCRtpReceiver) *)receiver
+      participantId:(NSString *)participantId
+          algorithm:(RTC_OBJC_TYPE(RTCCryptorAlgorithm))algorithm
+        keyProvider:(RTC_OBJC_TYPE(RTCFrameCryptorKeyProvider) *)keyProvider {
   self = [super init];
   if (self) {
     _lock = OS_UNFAIR_LOCK_INIT;
 
-    webrtc::scoped_refptr<webrtc::RtpReceiverInterface> nativeRtpReceiver = receiver.nativeRtpReceiver;
+    webrtc::scoped_refptr<webrtc::RtpReceiverInterface> nativeRtpReceiver =
+        receiver.nativeRtpReceiver;
     if (nativeRtpReceiver == nullptr) return nil;
 
-    webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> nativeTrack = nativeRtpReceiver->track();
+    webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> nativeTrack =
+        nativeRtpReceiver->track();
     if (nativeTrack == nullptr) return nil;
 
     webrtc::FrameCryptorTransformer::MediaType mediaType =
-        nativeTrack->kind() == "audio" ? webrtc::FrameCryptorTransformer::MediaType::kAudioFrame
-                                       : webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
+        nativeTrack->kind() == "audio" ?
+        webrtc::FrameCryptorTransformer::MediaType::kAudioFrame :
+        webrtc::FrameCryptorTransformer::MediaType::kVideoFrame;
 
     os_unfair_lock_lock(&_lock);
-    _observer = webrtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
+    _observer =
+        webrtc::make_ref_counted<webrtc::RTCFrameCryptorDelegateAdapter>(self);
     _participantId = participantId;
 
     _frame_crypto_transformer =
-        webrtc::scoped_refptr<webrtc::FrameCryptorTransformer>(new webrtc::FrameCryptorTransformer(
-            factory.signalingThread, [participantId stdString], mediaType,
-            [self algorithmFromEnum:algorithm], keyProvider.nativeKeyProvider));
+        webrtc::scoped_refptr<webrtc::FrameCryptorTransformer>(
+            new webrtc::FrameCryptorTransformer(
+                factory.signalingThread,
+                [participantId stdString],
+                mediaType,
+                [self algorithmFromEnum:algorithm],
+                keyProvider.nativeKeyProvider));
 
     factory.signalingThread->BlockingCall([self, nativeRtpReceiver] {
       // Must be called on signal thread
-      nativeRtpReceiver->SetDepacketizerToDecoderFrameTransformer(_frame_crypto_transformer);
+      nativeRtpReceiver->SetFrameTransformer(_frame_crypto_transformer);
     });
 
     _frame_crypto_transformer->SetEnabled(false);
-    _frame_crypto_transformer->RegisterFrameCryptorTransformerObserver(_observer);
+    _frame_crypto_transformer->RegisterFrameCryptorTransformerObserver(
+        _observer);
     os_unfair_lock_unlock(&_lock);
   }
 
@@ -205,7 +246,9 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 
 - (BOOL)enabled {
   os_unfair_lock_lock(&_lock);
-  BOOL result = _frame_crypto_transformer != nullptr ? _frame_crypto_transformer->enabled() : NO;
+  BOOL result = _frame_crypto_transformer != nullptr ?
+      _frame_crypto_transformer->enabled() :
+      NO;
   os_unfair_lock_unlock(&_lock);
   return result;
 }
@@ -220,7 +263,9 @@ void RTCFrameCryptorDelegateAdapter::OnFrameCryptionStateChanged(const std::stri
 
 - (int)keyIndex {
   os_unfair_lock_lock(&_lock);
-  int result = _frame_crypto_transformer != nullptr ? _frame_crypto_transformer->key_index() : 0;
+  int result = _frame_crypto_transformer != nullptr ?
+      _frame_crypto_transformer->key_index() :
+      0;
   os_unfair_lock_unlock(&_lock);
   return result;
 }

--- a/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
+++ b/sdk/objc/api/peerconnection/RTCFrameCryptorKeyProvider.mm
@@ -26,7 +26,7 @@
   webrtc::scoped_refptr<webrtc::DefaultKeyProviderImpl> _nativeKeyProvider;
 }
 
-- (rtc::scoped_refptr<webrtc::KeyProvider>)nativeKeyProvider {
+- (webrtc::scoped_refptr<webrtc::KeyProvider>)nativeKeyProvider {
   return _nativeKeyProvider;
 }
 
@@ -35,11 +35,11 @@
                       sharedKeyMode:(BOOL)sharedKey
                 uncryptedMagicBytes:(NSData *)uncryptedMagicBytes {
   return [self initWithRatchetSalt:salt
-                  ratchetWindowSize:windowSize
-                      sharedKeyMode:sharedKey
-                uncryptedMagicBytes:uncryptedMagicBytes
-                   failureTolerance:-1
-                   keyRingSize:webrtc::DEFAULT_KEYRING_SIZE];
+                 ratchetWindowSize:windowSize
+                     sharedKeyMode:sharedKey
+               uncryptedMagicBytes:uncryptedMagicBytes
+                  failureTolerance:-1
+                       keyRingSize:webrtc::DEFAULT_KEYRING_SIZE];
 }
 
 - (instancetype)initWithRatchetSalt:(NSData *)salt
@@ -49,12 +49,12 @@
                    failureTolerance:(int)failureTolerance
                         keyRingSize:(int)keyRingSize {
   return [self initWithRatchetSalt:salt
-                  ratchetWindowSize:windowSize
-                      sharedKeyMode:sharedKey
-                uncryptedMagicBytes:uncryptedMagicBytes
-                   failureTolerance:-1
-                   keyRingSize:keyRingSize
-                   discardFrameWhenCryptorNotReady:false];
+                    ratchetWindowSize:windowSize
+                        sharedKeyMode:sharedKey
+                  uncryptedMagicBytes:uncryptedMagicBytes
+                     failureTolerance:-1
+                          keyRingSize:keyRingSize
+      discardFrameWhenCryptorNotReady:false];
 }
 
 - (instancetype)initWithRatchetSalt:(NSData *)salt
@@ -67,33 +67,42 @@
   self = [super init];
   if (self) {
     webrtc::KeyProviderOptions options;
-    options.ratchet_salt = std::vector<uint8_t>((const uint8_t *)salt.bytes,
-                                                ((const uint8_t *)salt.bytes) + salt.length);
+    options.ratchet_salt =
+        std::vector<uint8_t>((const uint8_t *)salt.bytes,
+                             ((const uint8_t *)salt.bytes) + salt.length);
     options.ratchet_window_size = windowSize;
     options.shared_key = sharedKey;
     options.failure_tolerance = failureTolerance;
     options.key_ring_size = keyRingSize;
-    options.discard_frame_when_cryptor_not_ready = discardFrameWhenCryptorNotReady;
-    if(uncryptedMagicBytes != nil) {
-      options.uncrypted_magic_bytes = std::vector<uint8_t>((const uint8_t *)uncryptedMagicBytes.bytes,
-                                                          ((const uint8_t *)uncryptedMagicBytes.bytes) + uncryptedMagicBytes.length);
+    options.discard_frame_when_cryptor_not_ready =
+        discardFrameWhenCryptorNotReady;
+    if (uncryptedMagicBytes != nil) {
+      options.uncrypted_magic_bytes =
+          std::vector<uint8_t>((const uint8_t *)uncryptedMagicBytes.bytes,
+                               ((const uint8_t *)uncryptedMagicBytes.bytes) +
+                                   uncryptedMagicBytes.length);
     }
-    _nativeKeyProvider = webrtc::make_ref_counted<webrtc::DefaultKeyProviderImpl>(options);
+    _nativeKeyProvider =
+        webrtc::make_ref_counted<webrtc::DefaultKeyProviderImpl>(options);
   }
   return self;
 }
 
-- (void)setKey:(NSData *)key withIndex:(int)index forParticipant:(NSString *)participantId {
+- (void)setKey:(NSData *)key
+         withIndex:(int)index
+    forParticipant:(NSString *)participantId {
   _nativeKeyProvider->SetKey(
       [participantId stdString],
       index,
-      std::vector<uint8_t>((const uint8_t *)key.bytes, ((const uint8_t *)key.bytes) + key.length));
+      std::vector<uint8_t>((const uint8_t *)key.bytes,
+                           ((const uint8_t *)key.bytes) + key.length));
 }
 
 - (void)setSharedKey:(NSData *)key withIndex:(int)index {
   _nativeKeyProvider->SetSharedKey(
       index,
-      std::vector<uint8_t>((const uint8_t *)key.bytes, ((const uint8_t *)key.bytes) + key.length));
+      std::vector<uint8_t>((const uint8_t *)key.bytes,
+                           ((const uint8_t *)key.bytes) + key.length));
 }
 
 - (NSData *)ratchetSharedKey:(int)index {
@@ -107,12 +116,14 @@
 }
 
 - (NSData *)ratchetKey:(NSString *)participantId withIndex:(int)index {
-  std::vector<uint8_t> nativeKey = _nativeKeyProvider->RatchetKey([participantId stdString], index);
+  std::vector<uint8_t> nativeKey =
+      _nativeKeyProvider->RatchetKey([participantId stdString], index);
   return [NSData dataWithBytes:nativeKey.data() length:nativeKey.size()];
 }
 
 - (NSData *)exportKey:(NSString *)participantId withIndex:(int)index {
-  std::vector<uint8_t> nativeKey = _nativeKeyProvider->ExportKey([participantId stdString], index);
+  std::vector<uint8_t> nativeKey =
+      _nativeKeyProvider->ExportKey([participantId stdString], index);
   return [NSData dataWithBytes:nativeKey.data() length:nativeKey.size()];
 }
 

--- a/sdk/objc/native/api/audio_device_module.mm
+++ b/sdk/objc/native/api/audio_device_module.mm
@@ -44,6 +44,7 @@ webrtc::scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
 #endif
 }
 
+#if defined(WEBRTC_IOS)
 webrtc::scoped_refptr<AudioDeviceModule> CreateMutedDetectAudioDeviceModule(
     AudioDeviceModule::MutedSpeechEventHandler muted_speech_event_handler,
     bool bypass_voice_processing) {
@@ -79,13 +80,8 @@ webrtc::scoped_refptr<AudioDeviceModule> CreateMutedDetectAudioDeviceModule(
     ADMErrorHandler error_handler,
     bool bypass_voice_processing) {
   RTC_DLOG(LS_INFO) << __FUNCTION__;
-#if defined(WEBRTC_IOS)
   return webrtc::make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
       env, bypass_voice_processing, muted_speech_event_handler, error_handler);
-#else
-  RTC_LOG(LS_ERROR)
-      << "current platform is not supported => this module will self destruct!";
-  return nullptr;
-#endif
 }
+#endif
 }  // namespace webrtc

--- a/sdk/objc/native/src/objc_desktop_capture.h
+++ b/sdk/objc/native/src/objc_desktop_capture.h
@@ -21,8 +21,8 @@
 
 #include "api/video/i420_buffer.h"
 #include "api/video/video_frame.h"
-#include "modules/desktop_capture/desktop_capture_options.h"
 #include "modules/desktop_capture/desktop_and_cursor_composer.h"
+#include "modules/desktop_capture/desktop_capture_options.h"
 #include "modules/desktop_capture/desktop_frame.h"
 #include "rtc_base/thread.h"
 
@@ -35,12 +35,13 @@ enum DesktopType { kScreen, kWindow };
 
 class ObjCDesktopCapturer : public DesktopCapturer::Callback {
  public:
-  enum CaptureState { CS_RUNNING, CS_STOPPED, CS_FAILED};
+  enum CaptureState { CS_RUNNING, CS_STOPPED, CS_FAILED };
 
  public:
-  ObjCDesktopCapturer(DesktopType type,
-    webrtc::DesktopCapturer::SourceId source_id,
-    id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate);
+  ObjCDesktopCapturer(
+      DesktopType type,
+      webrtc::DesktopCapturer::SourceId source_id,
+      id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate);
   virtual ~ObjCDesktopCapturer();
 
   virtual CaptureState Start(uint32_t fps);
@@ -50,19 +51,22 @@ class ObjCDesktopCapturer : public DesktopCapturer::Callback {
   virtual bool IsRunning();
 
  protected:
-  virtual void OnCaptureResult(webrtc::DesktopCapturer::Result result,
-                               std::unique_ptr<webrtc::DesktopFrame> frame) override;
+  virtual void OnCaptureResult(
+      webrtc::DesktopCapturer::Result result,
+      std::unique_ptr<webrtc::DesktopFrame> frame) override;
+
  private:
   void CaptureFrame();
   webrtc::DesktopCaptureOptions options_;
   std::unique_ptr<webrtc::DesktopAndCursorComposer> capturer_;
-  std::unique_ptr<rtc::Thread> thread_;
+  std::unique_ptr<webrtc::Thread> thread_;
   CaptureState capture_state_ = CS_STOPPED;
   DesktopType type_;
   webrtc::DesktopCapturer::SourceId source_id_;
   id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate_;
-  uint32_t capture_delay_ = 1000; // 1s
-  webrtc::DesktopCapturer::Result result_ = webrtc::DesktopCapturer::Result::SUCCESS;
+  uint32_t capture_delay_ = 1000;  // 1s
+  webrtc::DesktopCapturer::Result result_ =
+      webrtc::DesktopCapturer::Result::SUCCESS;
 };
 
 }  // namespace webrtc

--- a/sdk/objc/native/src/objc_desktop_capture.mm
+++ b/sdk/objc/native/src/objc_desktop_capture.mm
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+#include "sdk/objc/native/src/objc_desktop_capture.h"
 #include "api/sequence_checker.h"
 #include "rtc_base/checks.h"
-#include "sdk/objc/native/src/objc_desktop_capture.h"
 #include "sdk/objc/native/src/objc_video_frame.h"
 #include "third_party/libyuv/include/libyuv.h"
 
@@ -27,10 +27,13 @@ namespace webrtc {
 
 enum { kCaptureDelay = 33, kCaptureMessageId = 1000 };
 
-ObjCDesktopCapturer::ObjCDesktopCapturer(DesktopType type,
-                                         webrtc::DesktopCapturer::SourceId source_id,
-                                         id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate)
-    : thread_(rtc::Thread::Create()), source_id_(source_id), delegate_(delegate) {
+ObjCDesktopCapturer::ObjCDesktopCapturer(
+    DesktopType type,
+    webrtc::DesktopCapturer::SourceId source_id,
+    id<RTC_OBJC_TYPE(RTCDesktopCapturerPrivateDelegate)> delegate)
+    : thread_(webrtc::Thread::Create()),
+      source_id_(source_id),
+      delegate_(delegate) {
   RTC_DCHECK(thread_);
   type_ = type;
   thread_->Start();
@@ -49,17 +52,15 @@ ObjCDesktopCapturer::ObjCDesktopCapturer(DesktopType type,
 }
 
 ObjCDesktopCapturer::~ObjCDesktopCapturer() {
-  thread_->BlockingCall([this] {
-    capturer_.reset();
-  });
+  thread_->BlockingCall([this] { capturer_.reset(); });
 }
 
 ObjCDesktopCapturer::CaptureState ObjCDesktopCapturer::Start(uint32_t fps) {
-  if(capture_state_  == CS_RUNNING) {
+  if (capture_state_ == CS_RUNNING) {
     return capture_state_;
   }
 
-  if(fps == 0) {
+  if (fps == 0) {
     capture_state_ = CS_FAILED;
     return capture_state_;
   }
@@ -83,14 +84,10 @@ ObjCDesktopCapturer::CaptureState ObjCDesktopCapturer::Start(uint32_t fps) {
     }
   }
 
-  thread_->BlockingCall([this] {
-    capturer_->Start(this);
-  });
+  thread_->BlockingCall([this] { capturer_->Start(this); });
   capture_state_ = CS_RUNNING;
 
-  thread_->PostTask([this] {
-    CaptureFrame();
-  });
+  thread_->PostTask([this] { CaptureFrame(); });
 
   [delegate_ didSourceCaptureStart];
   return capture_state_;
@@ -105,8 +102,9 @@ bool ObjCDesktopCapturer::IsRunning() {
   return capture_state_ == CS_RUNNING;
 }
 
-void ObjCDesktopCapturer::OnCaptureResult(webrtc::DesktopCapturer::Result result,
-                                          std::unique_ptr<webrtc::DesktopFrame> frame) {
+void ObjCDesktopCapturer::OnCaptureResult(
+    webrtc::DesktopCapturer::Result result,
+    std::unique_ptr<webrtc::DesktopFrame> frame) {
   if (result != result_) {
     if (result == webrtc::DesktopCapturer::Result::ERROR_PERMANENT) {
       [delegate_ didSourceCaptureError];
@@ -150,13 +148,15 @@ void ObjCDesktopCapturer::OnCaptureResult(webrtc::DesktopCapturer::Result result
 
   CVPixelBufferRef pixelBuffer = NULL;
 
-  NSDictionary *pixelAttributes = @{(NSString *)kCVPixelBufferIOSurfacePropertiesKey : @{}};
-  CVReturn res = CVPixelBufferCreate(kCFAllocatorDefault,
-                                     width,
-                                     height,
-                                     kCVPixelFormatType_32BGRA,
-                                     (__bridge CFDictionaryRef)(pixelAttributes),
-                                     &pixelBuffer);
+  NSDictionary *pixelAttributes =
+      @{(NSString *)kCVPixelBufferIOSurfacePropertiesKey : @{}};
+  CVReturn res =
+      CVPixelBufferCreate(kCFAllocatorDefault,
+                          width,
+                          height,
+                          kCVPixelFormatType_32BGRA,
+                          (__bridge CFDictionaryRef)(pixelAttributes),
+                          &pixelBuffer);
   CVPixelBufferLockBaseAddress(pixelBuffer, 0);
   uint8_t *pxdata = (uint8_t *)CVPixelBufferGetBaseAddress(pixelBuffer);
   libyuv::ConvertToARGB(reinterpret_cast<uint8_t *>(frame->data()),
@@ -182,10 +182,10 @@ void ObjCDesktopCapturer::OnCaptureResult(webrtc::DesktopCapturer::Result result
       [[RTC_OBJC_TYPE(RTCCVPixelBuffer) alloc] initWithPixelBuffer:pixelBuffer];
   NSTimeInterval timeStampSeconds = CACurrentMediaTime();
   int64_t timeStampNs = lroundf(timeStampSeconds * NSEC_PER_SEC);
-  RTC_OBJC_TYPE(RTCVideoFrame) *videoFrame =
-      [[RTC_OBJC_TYPE(RTCVideoFrame) alloc] initWithBuffer:rtcPixelBuffer
-                                                  rotation:RTC_OBJC_TYPE(RTCVideoRotation_0)
-                                               timeStampNs:timeStampNs];
+  RTC_OBJC_TYPE(RTCVideoFrame) *videoFrame = [[RTC_OBJC_TYPE(RTCVideoFrame)
+      alloc] initWithBuffer:rtcPixelBuffer
+                   rotation:RTC_OBJC_TYPE(RTCVideoRotation_0)
+                timeStampNs:timeStampNs];
   CVPixelBufferRelease(pixelBuffer);
   [delegate_ didCaptureVideoFrame:videoFrame];
 }
@@ -194,11 +194,8 @@ void ObjCDesktopCapturer::CaptureFrame() {
   RTC_DCHECK_RUN_ON(thread_.get());
   if (capture_state_ == CS_RUNNING) {
     capturer_->CaptureFrame();
-    thread_->PostDelayedHighPrecisionTask(
-      [this]() {
-        CaptureFrame();
-      },
-      TimeDelta::Millis(capture_delay_));
+    thread_->PostDelayedHighPrecisionTask([this]() { CaptureFrame(); },
+                                          TimeDelta::Millis(capture_delay_));
   }
 }
 

--- a/sdk/objc/native/src/objc_desktop_media_list.h
+++ b/sdk/objc/native/src/objc_desktop_media_list.h
@@ -17,24 +17,23 @@
 #ifndef SDK_OBJC_NATIVE_SRC_OBJC_DESKTOP_MEDIA_LIST_H_
 #define SDK_OBJC_NATIVE_SRC_OBJC_DESKTOP_MEDIA_LIST_H_
 
-#import "base/RTCMacros.h"
-
 #include "api/video/i420_buffer.h"
 #include "api/video/video_frame.h"
+#import "base/RTCMacros.h"
+#import "components/capturer/RTCDesktopMediaList+Private.h"
 #include "modules/desktop_capture/desktop_capture_options.h"
 #include "modules/desktop_capture/desktop_capturer.h"
 #include "modules/desktop_capture/desktop_frame.h"
-#include "rtc_base/thread.h"
-
 #include "objc_desktop_capture.h"
-
-#import "components/capturer/RTCDesktopMediaList+Private.h"
+#include "rtc_base/thread.h"
 
 namespace webrtc {
 
 class MediaSource {
  public:
-  MediaSource( ObjCDesktopMediaList *mediaList, DesktopCapturer::Source src, DesktopType type)
+  MediaSource(ObjCDesktopMediaList* mediaList,
+              DesktopCapturer::Source src,
+              DesktopType type)
       : source(src), mediaList_(mediaList), type_(type) {}
   virtual ~MediaSource() {}
 
@@ -49,8 +48,6 @@ class MediaSource {
   // Returns the thumbnail of the source, jpeg format.
   std::vector<unsigned char> thumbnail() const { return thumbnail_; }
 
-  
-
   DesktopType type() const { return type_; }
 
   bool UpdateThumbnail();
@@ -60,49 +57,58 @@ class MediaSource {
 
  private:
   std::vector<unsigned char> thumbnail_;
-  ObjCDesktopMediaList *mediaList_;
+  ObjCDesktopMediaList* mediaList_;
   DesktopType type_;
 };
 
 class ObjCDesktopMediaList {
  public:
-  enum CaptureState { CS_RUNNING, CS_STOPPED, CS_FAILED};
+  enum CaptureState { CS_RUNNING, CS_STOPPED, CS_FAILED };
+
  public:
-  ObjCDesktopMediaList(DesktopType type, RTC_OBJC_TYPE(RTCDesktopMediaList)* objcMediaList);
+  ObjCDesktopMediaList(DesktopType type,
+                       RTC_OBJC_TYPE(RTCDesktopMediaList) * objcMediaList);
 
   virtual ~ObjCDesktopMediaList();
 
-  virtual int32_t UpdateSourceList(bool force_reload = false, bool get_thumbnail = true);
+  virtual int32_t UpdateSourceList(bool force_reload = false,
+                                   bool get_thumbnail = true);
 
   virtual int GetSourceCount() const;
-  
+
   virtual MediaSource* GetSource(int index);
 
-  virtual bool GetThumbnail(MediaSource *source, bool notify);
+  virtual bool GetThumbnail(MediaSource* source, bool notify);
 
  private:
-    class CallbackProxy : public DesktopCapturer::Callback {
-        public:
-         CallbackProxy(){}
-          void SetCallback(std::function<void(webrtc::DesktopCapturer::Result result,
-                               std::unique_ptr<webrtc::DesktopFrame> frame)> on_capture_result) {
-                                on_capture_result_ = on_capture_result;
-                               }
-        private:
-         void OnCaptureResult(webrtc::DesktopCapturer::Result result,
-                               std::unique_ptr<webrtc::DesktopFrame> frame) override {
-                                    if(on_capture_result_) on_capture_result_(result, std::move(frame));
-                               }
+  class CallbackProxy : public DesktopCapturer::Callback {
+   public:
+    CallbackProxy() {}
+    void SetCallback(
         std::function<void(webrtc::DesktopCapturer::Result result,
-                               std::unique_ptr<webrtc::DesktopFrame> frame)> on_capture_result_ = nullptr;
-    };
+                           std::unique_ptr<webrtc::DesktopFrame> frame)>
+            on_capture_result) {
+      on_capture_result_ = on_capture_result;
+    }
+
+   private:
+    void OnCaptureResult(webrtc::DesktopCapturer::Result result,
+                         std::unique_ptr<webrtc::DesktopFrame> frame) override {
+      if (on_capture_result_)
+        on_capture_result_(result, std::move(frame));
+    }
+    std::function<void(webrtc::DesktopCapturer::Result result,
+                       std::unique_ptr<webrtc::DesktopFrame> frame)>
+        on_capture_result_ = nullptr;
+  };
+
  private:
   std::unique_ptr<CallbackProxy> callback_;
   webrtc::DesktopCaptureOptions options_;
   std::unique_ptr<webrtc::DesktopCapturer> capturer_;
-  std::unique_ptr<rtc::Thread> thread_;
+  std::unique_ptr<webrtc::Thread> thread_;
   std::vector<std::shared_ptr<MediaSource>> sources_;
-  RTC_OBJC_TYPE(RTCDesktopMediaList)* objcMediaList_;
+  RTC_OBJC_TYPE(RTCDesktopMediaList) * objcMediaList_;
   DesktopType type_;
 };
 

--- a/sdk/objc/native/src/objc_desktop_media_list.mm
+++ b/sdk/objc/native/src/objc_desktop_media_list.mm
@@ -36,8 +36,11 @@ extern "C" {
 namespace webrtc {
 
 ObjCDesktopMediaList::ObjCDesktopMediaList(DesktopType type,
-                                           RTC_OBJC_TYPE(RTCDesktopMediaList) * objcMediaList)
-    : thread_(rtc::Thread::Create()), objcMediaList_(objcMediaList), type_(type) {
+                                           RTC_OBJC_TYPE(RTCDesktopMediaList) *
+                                               objcMediaList)
+    : thread_(webrtc::Thread::Create()),
+      objcMediaList_(objcMediaList),
+      type_(type) {
   RTC_DCHECK(thread_);
   thread_->Start();
   options_ = webrtc::DesktopCaptureOptions::CreateDefault();
@@ -47,7 +50,7 @@ ObjCDesktopMediaList::ObjCDesktopMediaList(DesktopType type,
   callback_ = std::make_unique<CallbackProxy>();
 
   thread_->BlockingCall([this, type] {
-     if (type == kScreen) {
+    if (type == kScreen) {
       capturer_ = webrtc::DesktopCapturer::CreateScreenCapturer(options_);
     } else {
       capturer_ = webrtc::DesktopCapturer::CreateWindowCapturer(options_);
@@ -57,12 +60,11 @@ ObjCDesktopMediaList::ObjCDesktopMediaList(DesktopType type,
 }
 
 ObjCDesktopMediaList::~ObjCDesktopMediaList() {
-  thread_->BlockingCall([this] {
-    capturer_.reset();
-  });
+  thread_->BlockingCall([this] { capturer_.reset(); });
 }
 
-int32_t ObjCDesktopMediaList::UpdateSourceList(bool force_reload, bool get_thumbnail) {
+int32_t ObjCDesktopMediaList::UpdateSourceList(bool force_reload,
+                                               bool get_thumbnail) {
   if (force_reload) {
     for (auto source : sources_) {
       [objcMediaList_ mediaSourceRemoved:source.get()];
@@ -72,9 +74,8 @@ int32_t ObjCDesktopMediaList::UpdateSourceList(bool force_reload, bool get_thumb
 
   webrtc::DesktopCapturer::SourceList new_sources;
 
-  thread_->BlockingCall([this, &new_sources] {
-    capturer_->GetSourceList(&new_sources);
-  });
+  thread_->BlockingCall(
+      [this, &new_sources] { capturer_->GetSourceList(&new_sources); });
 
   typedef std::set<DesktopCapturer::SourceId> SourceSet;
   SourceSet new_source_set;
@@ -101,7 +102,8 @@ int32_t ObjCDesktopMediaList::UpdateSourceList(bool force_reload, bool get_thumb
     for (size_t i = 0; i < new_sources.size(); ++i) {
       if (old_source_set.find(new_sources[i].id) == old_source_set.end()) {
         MediaSource *source = new MediaSource(this, new_sources[i], type_);
-        sources_.insert(sources_.begin() + i, std::shared_ptr<MediaSource>(source));
+        sources_.insert(sources_.begin() + i,
+                        std::shared_ptr<MediaSource>(source));
         [objcMediaList_ mediaSourceAdded:source];
         GetThumbnail(source, true);
       }
@@ -146,17 +148,17 @@ int32_t ObjCDesktopMediaList::UpdateSourceList(bool force_reload, bool get_thumb
 
 bool ObjCDesktopMediaList::GetThumbnail(MediaSource *source, bool notify) {
   thread_->PostTask([this, source, notify] {
-      if(capturer_->SelectSource(source->id())){
-        callback_->SetCallback([&](webrtc::DesktopCapturer::Result result,
-                             std::unique_ptr<webrtc::DesktopFrame> frame) {
-          auto old_thumbnail = source->thumbnail();
-          source->SaveCaptureResult(result, std::move(frame));
-          if(old_thumbnail.size() != source->thumbnail().size() && notify) {
-            [objcMediaList_ mediaSourceThumbnailChanged:source];
-          }
-        });
-        capturer_->CaptureFrame();
-      }
+    if (capturer_->SelectSource(source->id())) {
+      callback_->SetCallback([&](webrtc::DesktopCapturer::Result result,
+                                 std::unique_ptr<webrtc::DesktopFrame> frame) {
+        auto old_thumbnail = source->thumbnail();
+        source->SaveCaptureResult(result, std::move(frame));
+        if (old_thumbnail.size() != source->thumbnail().size() && notify) {
+          [objcMediaList_ mediaSourceThumbnailChanged:source];
+        }
+      });
+      capturer_->CaptureFrame();
+    }
   });
 
   return true;
@@ -174,8 +176,9 @@ bool MediaSource::UpdateThumbnail() {
   return mediaList_->GetThumbnail(this, true);
 }
 
-void MediaSource::SaveCaptureResult(webrtc::DesktopCapturer::Result result,
-                                    std::unique_ptr<webrtc::DesktopFrame> frame) {
+void MediaSource::SaveCaptureResult(
+    webrtc::DesktopCapturer::Result result,
+    std::unique_ptr<webrtc::DesktopFrame> frame) {
   if (result != webrtc::DesktopCapturer::Result::SUCCESS) {
     return;
   }
@@ -199,13 +202,15 @@ void MediaSource::SaveCaptureResult(webrtc::DesktopCapturer::Result result,
 
   CVPixelBufferRef pixelBuffer = NULL;
 
-  NSDictionary *pixelAttributes = @{(NSString *)kCVPixelBufferIOSurfacePropertiesKey : @{}};
-  CVReturn res = CVPixelBufferCreate(kCFAllocatorDefault,
-                                     width,
-                                     height,
-                                     kCVPixelFormatType_32BGRA,
-                                     (__bridge CFDictionaryRef)(pixelAttributes),
-                                     &pixelBuffer);
+  NSDictionary *pixelAttributes =
+      @{(NSString *)kCVPixelBufferIOSurfacePropertiesKey : @{}};
+  CVReturn res =
+      CVPixelBufferCreate(kCFAllocatorDefault,
+                          width,
+                          height,
+                          kCVPixelFormatType_32BGRA,
+                          (__bridge CFDictionaryRef)(pixelAttributes),
+                          &pixelBuffer);
   CVPixelBufferLockBaseAddress(pixelBuffer, 0);
   uint8_t *pxdata = (uint8_t *)CVPixelBufferGetBaseAddress(pixelBuffer);
   libyuv::ConvertToARGB(reinterpret_cast<uint8_t *>(frame->data()),

--- a/sdk/objc/native/src/objc_video_encoder_factory.mm
+++ b/sdk/objc/native/src/objc_video_encoder_factory.mm
@@ -134,8 +134,17 @@ class ObjCVideoEncoder : public VideoEncoder {
 
     RTC_OBJC_TYPE(RTCVideoEncoderQpThresholds) *qp_thresholds =
         [encoder_ scalingSettings];
+    // The default kDefaultMinPixelsPerFrame (320*180 = 57600) is too
+    // conservative for iOS hardware encoders (VideoToolbox). It prevents
+    // the quality scaler from reducing resolution below ~180x320 (the
+    // quarter-resolution simulcast layer for 720p), which limits adaptation
+    // range on constrained networks (e.g. 3G). VideoToolbox can encode at
+    // resolutions well below this threshold, so we use a lower floor to
+    // allow meaningful quality adaptation in bandwidth-limited scenarios.
+    constexpr int kObjCEncoderMinPixelsPerFrame = 90 * 160;
     info.scaling_settings = qp_thresholds ?
-        ScalingSettings(qp_thresholds.low, qp_thresholds.high) :
+        ScalingSettings(qp_thresholds.low, qp_thresholds.high,
+                        kObjCEncoderMinPixelsPerFrame) :
         ScalingSettings::kOff;
 
     info.requested_resolution_alignment = encoder_.resolutionAlignment > 0 ?: 1;

--- a/sdk/objc/unittests/RTCCameraVideoCapturerTests.mm
+++ b/sdk/objc/unittests/RTCCameraVideoCapturerTests.mm
@@ -121,8 +121,10 @@ CMSampleBufferRef createTestSampleBufferRef() {
 - (void)tearDown {
   [self.delegateMock stopMocking];
   [self.deviceMock stopMocking];
+  [self.captureConnectionMock stopMocking];
   self.delegateMock = nil;
   self.deviceMock = nil;
+  self.captureConnectionMock = nil;
   self.capturer = nil;
 }
 
@@ -455,10 +457,11 @@ CMSampleBufferRef createTestSampleBufferRef() {
 - (void)tearDown {
   [self.delegateMock stopMocking];
   [self.deviceMock stopMocking];
+  [self.captureSessionMock stopMocking];
   self.delegateMock = nil;
   self.deviceMock = nil;
-  self.capturer = nil;
   self.captureSessionMock = nil;
+  self.capturer = nil;
 }
 
 #pragma mark - test cases

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm
@@ -9,14 +9,8 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <objc/runtime.h>
 #import <XCTest/XCTest.h>
-#ifdef __cplusplus
-extern "C" {
-#endif
-#import <OCMock/OCMock.h>
-#ifdef __cplusplus
-}
-#endif
 #import "api/peerconnection/RTCPeerConnectionFactory+Native.h"
 #import "api/peerconnection/RTCPeerConnectionFactoryBuilder+DefaultComponents.h"
 #import "api/peerconnection/RTCPeerConnectionFactoryBuilder.h"
@@ -28,8 +22,37 @@ extern "C" {
 #include "api/video_codecs/video_decoder_factory.h"
 #include "api/video_codecs/video_encoder_factory.h"
 
+#include <utility>
+
 #include "rtc_base/gunit.h"
-#include "rtc_base/system/unused.h"
+
+namespace {
+
+id StubInitWithMediaAndDependencies(
+    RTC_OBJC_TYPE(RTCPeerConnectionFactory) * factory,
+    SEL selector,
+    webrtc::PeerConnectionFactoryDependencies dependencies) {
+  return factory;
+}
+
+RTC_OBJC_TYPE(RTCPeerConnectionFactory) *
+    CreatePeerConnectionFactoryWithStubbedNativeInitializer(
+        RTCPeerConnectionFactoryBuilder *builder) {
+  Method initializer = class_getInstanceMethod(
+      [RTC_OBJC_TYPE(RTCPeerConnectionFactory) class],
+      @selector(initWithMediaAndDependencies:));
+  IMP original_initializer =
+      method_setImplementation(initializer,
+                               reinterpret_cast<IMP>(
+                                   &StubInitWithMediaAndDependencies));
+  @try {
+    return [builder createPeerConnectionFactory];
+  } @finally {
+    method_setImplementation(initializer, original_initializer);
+  }
+}
+
+}  // namespace
 
 @interface RTCPeerConnectionFactoryBuilderTests : XCTestCase
 @end
@@ -37,27 +60,14 @@ extern "C" {
 @implementation RTCPeerConnectionFactoryBuilderTests
 
 - (void)testBuilder {
-  id factoryMock =
-      OCMStrictClassMock([RTC_OBJC_TYPE(RTCPeerConnectionFactory) class]);
-  OCMExpect([factoryMock alloc]).andReturn(factoryMock);
-  webrtc::PeerConnectionFactoryDependencies default_deps;
-  RTC_UNUSED([[[[factoryMock expect] andReturn:factoryMock]
-      ignoringNonObjectArgs] initWithMediaAndDependencies:default_deps]);
   RTCPeerConnectionFactoryBuilder* builder =
       [[RTCPeerConnectionFactoryBuilder alloc] init];
   RTC_OBJC_TYPE(RTCPeerConnectionFactory)* peerConnectionFactory =
-      [builder createPeerConnectionFactory];
+      CreatePeerConnectionFactoryWithStubbedNativeInitializer(builder);
   EXPECT_TRUE(peerConnectionFactory != nil);
-  OCMVerifyAll(factoryMock);
 }
 
 - (void)testAudioDeviceModuleBuilder {
-  id factoryMock =
-      OCMStrictClassMock([RTC_OBJC_TYPE(RTCPeerConnectionFactory) class]);
-  OCMExpect([factoryMock alloc]).andReturn(factoryMock);
-  webrtc::PeerConnectionFactoryDependencies default_deps;
-  RTC_UNUSED([[[[factoryMock expect] andReturn:factoryMock]
-      ignoringNonObjectArgs] initWithMediaAndDependencies:default_deps]);
   RTCPeerConnectionFactoryBuilder* builder =
       [RTCPeerConnectionFactoryBuilder builder];
   __block int calledAdmBuilder = 0;
@@ -66,24 +76,16 @@ extern "C" {
     return webrtc::scoped_refptr<webrtc::AudioDeviceModule>(nullptr);
   }];
   RTC_OBJC_TYPE(RTCPeerConnectionFactory)* peerConnectionFactory =
-      [builder createPeerConnectionFactory];
+      CreatePeerConnectionFactoryWithStubbedNativeInitializer(builder);
   EXPECT_TRUE(peerConnectionFactory != nil);
   EXPECT_EQ(calledAdmBuilder, 1);
-  OCMVerifyAll(factoryMock);
 }
 
 - (void)testDefaultComponentsBuilder {
-  id factoryMock =
-      OCMStrictClassMock([RTC_OBJC_TYPE(RTCPeerConnectionFactory) class]);
-  OCMExpect([factoryMock alloc]).andReturn(factoryMock);
-  webrtc::PeerConnectionFactoryDependencies default_deps;
-  RTC_UNUSED([[[[factoryMock expect] andReturn:factoryMock]
-      ignoringNonObjectArgs] initWithMediaAndDependencies:default_deps]);
   RTCPeerConnectionFactoryBuilder* builder =
       [RTCPeerConnectionFactoryBuilder defaultBuilder];
   RTC_OBJC_TYPE(RTCPeerConnectionFactory)* peerConnectionFactory =
-      [builder createPeerConnectionFactory];
+      CreatePeerConnectionFactoryWithStubbedNativeInitializer(builder);
   EXPECT_TRUE(peerConnectionFactory != nil);
-  OCMVerifyAll(factoryMock);
 }
 @end

--- a/video/adaptation/video_stream_encoder_resource_manager.cc
+++ b/video/adaptation/video_stream_encoder_resource_manager.cc
@@ -565,16 +565,86 @@ void VideoStreamEncoderResourceManager::UpdateBandwidthQualityScalerSettings(
   }
 }
 
+void VideoStreamEncoderResourceManager::ResetAdaptationsForSimulcastChange() {
+  RTC_DCHECK_RUN_ON(encoder_queue_);
+  std::vector<scoped_refptr<Resource>> quality_resources;
+  for (const auto& resource_and_reason : resources_) {
+    if (resource_and_reason.second == VideoAdaptationReason::kQuality) {
+      quality_resources.push_back(resource_and_reason.first);
+    }
+  }
+
+  if (quality_resources.empty()) {
+    return;
+  }
+
+  for (const auto& resource : quality_resources) {
+    if (resource == quality_scaler_resource_) {
+      RTC_LOG(LS_INFO) << "Clearing quality scaler restrictions for simulcast "
+                          "active-layer transition.";
+      quality_scaler_resource_->StopCheckForOveruse();
+      RemoveResource(resource);
+      initial_frame_dropper_->OnQualityScalerSettingsUpdated();
+    } else if (resource == bandwidth_quality_scaler_resource_) {
+      RTC_LOG(LS_INFO)
+          << "Clearing bandwidth quality scaler restrictions for simulcast "
+             "active-layer transition.";
+      bandwidth_quality_scaler_resource_->StopCheckForOveruse();
+      RemoveResource(resource);
+    } else {
+      RTC_LOG(LS_INFO) << "Resetting quality adaptation resource \""
+                       << resource->Name()
+                       << "\" for simulcast active-layer transition.";
+      RemoveResource(resource);
+      AddResource(resource, VideoAdaptationReason::kQuality);
+    }
+  }
+
+  UpdateStatsAdaptationSettings();
+}
+
+void VideoStreamEncoderResourceManager::SetSimulcastActive(
+    bool simulcast_active) {
+  RTC_DCHECK_RUN_ON(encoder_queue_);
+  if (simulcast_active_ != simulcast_active) {
+    RTC_LOG(LS_INFO) << "SetSimulcastActive: " << simulcast_active_
+                     << " -> " << simulcast_active;
+  }
+  simulcast_active_ = simulcast_active;
+}
+
 void VideoStreamEncoderResourceManager::ConfigureQualityScaler(
     const VideoEncoder::EncoderInfo& encoder_info) {
   RTC_DCHECK_RUN_ON(encoder_queue_);
   const auto scaling_settings = encoder_info.scaling_settings;
+  // Quality scaling (adapting input resolution based on encoded QP) is allowed
+  // only when ALL of the following are true:
+  //  1. The degradation preference permits resolution changes.
+  //  2. Simulcast is NOT active — during simulcast, the SFU handles quality
+  //     adaptation by activating/deactivating layers. Allowing the quality
+  //     scaler to run would shrink the input resolution and cause all
+  //     simulcast layer dimensions to be recomputed from degraded input.
+  //  3. The encoder reports QP thresholds or the encoder config explicitly
+  //     allows quality scaling (is_quality_scaling_allowed).
+  //  4. The encoder's QP values are trusted for scaling decisions.
+  const bool resolution_scaling_enabled =
+      IsResolutionScalingEnabled(degradation_preference_);
+  const bool has_scaling_thresholds =
+      scaling_settings.thresholds.has_value() ||
+      (encoder_settings_.has_value() &&
+       encoder_settings_->encoder_config().is_quality_scaling_allowed);
+  const bool qp_trusted = encoder_info.is_qp_trusted.value_or(true);
   const bool quality_scaling_allowed =
-      IsResolutionScalingEnabled(degradation_preference_) &&
-      (scaling_settings.thresholds.has_value() ||
-       (encoder_settings_.has_value() &&
-        encoder_settings_->encoder_config().is_quality_scaling_allowed)) &&
-      encoder_info.is_qp_trusted.value_or(true);
+      resolution_scaling_enabled && !simulcast_active_ &&
+      has_scaling_thresholds && qp_trusted;
+
+  RTC_LOG(LS_INFO) << "ConfigureQualityScaler: allowed=" << quality_scaling_allowed
+                   << " (resolution_scaling=" << resolution_scaling_enabled
+                   << ", simulcast_active=" << simulcast_active_
+                   << ", has_thresholds=" << has_scaling_thresholds
+                   << ", qp_trusted=" << qp_trusted
+                   << ", scaler_running=" << quality_scaler_resource_->is_started()
+                   << ")";
 
   // TODO(https://crbug.com/webrtc/11222): Should this move to
   // QualityScalerResource?
@@ -615,6 +685,7 @@ void VideoStreamEncoderResourceManager::ConfigureBandwidthQualityScaler(
   RTC_DCHECK_RUN_ON(encoder_queue_);
   const bool bandwidth_quality_scaling_allowed =
       IsResolutionScalingEnabled(degradation_preference_) &&
+      !simulcast_active_ &&
       (encoder_settings_.has_value() &&
        encoder_settings_->encoder_config().is_quality_scaling_allowed) &&
       !encoder_info.is_qp_trusted.value_or(true);

--- a/video/adaptation/video_stream_encoder_resource_manager.h
+++ b/video/adaptation/video_stream_encoder_resource_manager.h
@@ -109,6 +109,21 @@ class VideoStreamEncoderResourceManager
   // TODO(https://crbug.com/webrtc/11338): This can be made private if we
   // configure on SetDegredationPreference and SetEncoderSettings.
   void ConfigureQualityScaler(const VideoEncoder::EncoderInfo& encoder_info);
+
+  // Controls whether the quality scaler is suppressed due to simulcast.
+  // When multiple simulcast layers are active, resolution-based quality
+  // adaptation must be disabled because the quality scaler would shrink the
+  // input resolution, causing all simulcast layer dimensions to be derived
+  // from the degraded input rather than the original capture resolution.
+  // In simulcast mode, quality adaptation is handled by the SFU
+  // activating/deactivating layers instead.
+  void SetSimulcastActive(bool simulcast_active);
+
+  // Stops the quality scaler and clears its accumulated adaptation
+  // restrictions. Called when the number of active simulcast layers increases
+  // from <=1 to >1, so that the source provides full-resolution frames for
+  // the new multi-layer configuration.
+  void ResetAdaptationsForSimulcastChange();
   void ConfigureBandwidthQualityScaler(
       const VideoEncoder::EncoderInfo& encoder_info);
 
@@ -219,6 +234,13 @@ class VideoStreamEncoderResourceManager
       RTC_GUARDED_BY(encoder_queue_);
   std::optional<EncoderSettings> encoder_settings_
       RTC_GUARDED_BY(encoder_queue_);
+
+  // True when multiple simulcast layers are active. While set, the quality
+  // scaler is suppressed to prevent input resolution degradation that would
+  // corrupt simulcast layer dimensions. Set by VideoStreamEncoder from the
+  // current runtime layer allocation, with encoder-config fallback before the
+  // first SetRates() arrives.
+  bool simulcast_active_ RTC_GUARDED_BY(encoder_queue_) = false;
 
   // Ties a resource to a reason for statistical reporting. This AdaptReason is
   // also used by this module to make decisions about how to adapt up/down.

--- a/video/config/encoder_stream_factory.cc
+++ b/video/config/encoder_stream_factory.cc
@@ -85,13 +85,15 @@ bool IsTemporalLayersSupported(VideoCodecType codec_type) {
 }
 
 size_t FindRequiredActiveLayers(const VideoEncoderConfig& encoder_config) {
-  // Need enough layers so that at least the first active one is present.
+  // Need enough layers so that all active ones are present.
+  // Return the position after the highest active layer.
+  size_t highest = 0;
   for (size_t i = 0; i < encoder_config.number_of_streams; ++i) {
     if (encoder_config.simulcast_layers[i].active) {
-      return i + 1;
+      highest = i + 1;
     }
   }
-  return 0;
+  return highest;
 }
 
 // The selected thresholds for QVGA and VGA corresponded to a QP around 10.

--- a/video/config/encoder_stream_factory_unittest.cc
+++ b/video/config/encoder_stream_factory_unittest.cc
@@ -477,12 +477,68 @@ TEST(EncoderStreamFactory, ReducesStreamCountWhenResolutionIsLow) {
       SizeIs(1));
 }
 
-TEST(EncoderStreamFactory, ReducesStreamCountDownToFirstActiveStream) {
+TEST(EncoderStreamFactory, KeepsStreamCountToIncludeHighestActiveLayer) {
   EXPECT_THAT(
       CreateStreamResolutions({.number_of_streams = 3,
                                .resolution = {.width = 100, .height = 100},
                                .first_active_layer_idx = 1}),
-      SizeIs(2));
+      SizeIs(3));
+}
+
+TEST(EncoderStreamFactory, KeepsAllStreamsForSparseActivePattern) {
+  ExplicitKeyValueConfig field_trials("");
+  VideoEncoderConfig encoder_config;
+  encoder_config.codec_type = VideoCodecType::kVideoCodecVP8;
+  encoder_config.number_of_streams = 3;
+  encoder_config.simulcast_layers.resize(3);
+  encoder_config.simulcast_layers[0].active = true;
+  encoder_config.simulcast_layers[1].active = false;
+  encoder_config.simulcast_layers[2].active = true;
+  auto streams = CreateEncoderStreams(
+      field_trials, {.width = 100, .height = 100}, encoder_config);
+  EXPECT_THAT(streams, SizeIs(3));
+}
+
+TEST(EncoderStreamFactory, KeepsStreamsForHighAndLowActive) {
+  ExplicitKeyValueConfig field_trials("");
+  VideoEncoderConfig encoder_config;
+  encoder_config.codec_type = VideoCodecType::kVideoCodecVP8;
+  encoder_config.number_of_streams = 3;
+  encoder_config.simulcast_layers.resize(3);
+  encoder_config.simulcast_layers[0].active = true;
+  encoder_config.simulcast_layers[1].active = true;
+  encoder_config.simulcast_layers[2].active = false;
+  auto streams = CreateEncoderStreams(
+      field_trials, {.width = 100, .height = 100}, encoder_config);
+  EXPECT_THAT(streams, SizeIs(2));
+}
+
+TEST(EncoderStreamFactory, KeepsStreamsForOnlyHighestActive) {
+  ExplicitKeyValueConfig field_trials("");
+  VideoEncoderConfig encoder_config;
+  encoder_config.codec_type = VideoCodecType::kVideoCodecVP8;
+  encoder_config.number_of_streams = 3;
+  encoder_config.simulcast_layers.resize(3);
+  encoder_config.simulcast_layers[0].active = false;
+  encoder_config.simulcast_layers[1].active = false;
+  encoder_config.simulcast_layers[2].active = true;
+  auto streams = CreateEncoderStreams(
+      field_trials, {.width = 100, .height = 100}, encoder_config);
+  EXPECT_THAT(streams, SizeIs(3));
+}
+
+TEST(EncoderStreamFactory, ReducesToOneStreamWhenOnlyLowestActive) {
+  ExplicitKeyValueConfig field_trials("");
+  VideoEncoderConfig encoder_config;
+  encoder_config.codec_type = VideoCodecType::kVideoCodecVP8;
+  encoder_config.number_of_streams = 3;
+  encoder_config.simulcast_layers.resize(3);
+  encoder_config.simulcast_layers[0].active = true;
+  encoder_config.simulcast_layers[1].active = false;
+  encoder_config.simulcast_layers[2].active = false;
+  auto streams = CreateEncoderStreams(
+      field_trials, {.width = 100, .height = 100}, encoder_config);
+  EXPECT_THAT(streams, SizeIs(1));
 }
 
 TEST(EncoderStreamFactory,

--- a/video/video_stream_encoder.cc
+++ b/video/video_stream_encoder.cc
@@ -1102,6 +1102,8 @@ void VideoStreamEncoder::ReconfigureEncoder() {
   AlignmentAdjuster::GetAlignmentAndMaybeAdjustScaleFactors(
       encoder_->GetEncoderInfo(), &encoder_config_, std::nullopt);
 
+  UpdateSimulcastAdaptationState(GetNumActiveSimulcastLayers());
+
   std::vector<VideoStream> streams;
   if (encoder_config_.video_stream_factory) {
     // Note: only tests set their own EncoderStreamFactory...
@@ -1815,6 +1817,8 @@ void VideoStreamEncoder::SetEncoderRates(
     last_encoder_rate_settings_ = rate_settings;
   }
 
+  UpdateSimulcastAdaptationState(GetNumActiveSimulcastLayers());
+
   if (!encoder_)
     return;
 
@@ -1921,6 +1925,78 @@ void VideoStreamEncoder::OnFramePrepared(size_t frame_id) {
     MaybeEncodeVideoFrame(front.frame, front.time_when_posted_us);
     pending_mapped_frames_.pop_front();
   }
+}
+
+size_t VideoStreamEncoder::GetNumActiveSimulcastLayers() const {
+  RTC_DCHECK_RUN_ON(encoder_queue_.get());
+  if (last_encoder_rate_settings_.has_value()) {
+    size_t num_active_layers = 0;
+    for (size_t i = 0; i < encoder_config_.number_of_streams; ++i) {
+      if (last_encoder_rate_settings_->rate_control.target_bitrate
+              .GetSpatialLayerSum(i) > 0) {
+        ++num_active_layers;
+      }
+    }
+    return num_active_layers;
+  }
+
+  size_t num_active_layers = 0;
+  for (size_t i = 0; i < encoder_config_.number_of_streams; ++i) {
+    if (encoder_config_.simulcast_layers[i].active) {
+      ++num_active_layers;
+    }
+  }
+  return num_active_layers;
+}
+
+void VideoStreamEncoder::UpdateSimulcastAdaptationState(
+    size_t num_active_layers) {
+  RTC_DCHECK_RUN_ON(encoder_queue_.get());
+  // Determine whether we are effectively in simulcast mode based on the
+  // number of active runtime layers, not only the configured streams. The
+  // encoder config may keep 3 streams configured while SetRates() collapses
+  // publishing down to a single layer, or expands it back to simulcast,
+  // without a fresh ConfigureEncoder() call.
+  const bool is_simulcast = num_active_layers > 1;
+  const bool was_simulcast = prev_num_active_simulcast_layers_ > 1;
+
+  RTC_LOG(LS_INFO) << "[VSE] Simulcast state: active_layers="
+                   << num_active_layers
+                   << ", prev_active_layers="
+                   << prev_num_active_simulcast_layers_
+                   << ", streams=" << encoder_config_.number_of_streams
+                   << ", is_simulcast=" << is_simulcast
+                   << ", was_simulcast=" << was_simulcast;
+
+  if (is_simulcast &&
+      (!was_simulcast ||
+       num_active_layers > prev_num_active_simulcast_layers_)) {
+    // Whenever the active simulcast layer count increases, disable the
+    // quality scaler and clear any accumulated resolution restrictions so the
+    // source can return to full-resolution input for the larger runtime layer
+    // set. The guard on prev > 0 avoids clearing on the very first encoder
+    // configuration where no restrictions exist yet.
+    RTC_LOG(LS_INFO) << "[VSE] Active-layer increase -> simulcast: disabling "
+                        "quality scaler, clearing accumulated restrictions.";
+    stream_resource_manager_.SetSimulcastActive(true);
+    if (prev_num_active_simulcast_layers_ > 0) {
+      stream_resource_manager_.ResetAdaptationsForSimulcastChange();
+    }
+  } else if (!is_simulcast && was_simulcast) {
+    RTC_LOG(LS_INFO) << "[VSE] Transition -> single stream: quality scaler "
+                        "will be re-enabled.";
+    stream_resource_manager_.SetSimulcastActive(false);
+  } else if (is_simulcast) {
+    RTC_LOG(LS_INFO) << "[VSE] Staying in simulcast: quality scaler remains "
+                        "disabled.";
+    stream_resource_manager_.SetSimulcastActive(true);
+  } else {
+    RTC_LOG(LS_INFO) << "[VSE] Staying in single stream: quality scaler "
+                        "remains enabled.";
+    stream_resource_manager_.SetSimulcastActive(false);
+  }
+
+  prev_num_active_simulcast_layers_ = num_active_layers;
 }
 
 void VideoStreamEncoder::MaybeEncodeVideoFrame(const VideoFrame& video_frame,

--- a/video/video_stream_encoder.h
+++ b/video/video_stream_encoder.h
@@ -276,6 +276,9 @@ class VideoStreamEncoder : public VideoStreamEncoderInterface,
   uint32_t GetInputFramerateFps() RTC_RUN_ON(encoder_queue_);
   void SetEncoderRates(const EncoderRateSettings& rate_settings)
       RTC_RUN_ON(encoder_queue_);
+  size_t GetNumActiveSimulcastLayers() const RTC_RUN_ON(encoder_queue_);
+  void UpdateSimulcastAdaptationState(size_t num_active_layers)
+      RTC_RUN_ON(encoder_queue_);
 
   void RunPostEncode(const EncodedImage& encoded_image,
                      int64_t time_sent_us,
@@ -344,6 +347,10 @@ class VideoStreamEncoder : public VideoStreamEncoderInterface,
   std::optional<VideoFrameInfo> last_frame_info_ RTC_GUARDED_BY(encoder_queue_);
   int crop_width_ RTC_GUARDED_BY(encoder_queue_) = 0;
   int crop_height_ RTC_GUARDED_BY(encoder_queue_) = 0;
+  // Tracks the runtime number of active spatial layers so quality-scaler
+  // transitions follow the current rate allocation, not only the latest
+  // encoder configuration.
+  size_t prev_num_active_simulcast_layers_ RTC_GUARDED_BY(encoder_queue_) = 0;
   std::optional<uint32_t> encoder_target_bitrate_bps_
       RTC_GUARDED_BY(encoder_queue_);
   size_t max_data_payload_length_ RTC_GUARDED_BY(encoder_queue_) = 0;

--- a/video/video_stream_encoder_unittest.cc
+++ b/video/video_stream_encoder_unittest.cc
@@ -10,6 +10,7 @@
 #include "video/video_stream_encoder.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -176,6 +177,40 @@ constexpr uint8_t kCodedFrameVp8Qp25[] = {
 // Default value from encoder_info_settings.cc
 constexpr DataRate kDefaultH265Bitrate180p = DataRate::KilobitsPerSec(150);
 #endif
+
+VideoEncoderConfig Make3LayerVp8SimulcastConfig(
+    const std::array<bool, 3>& active_layers) {
+  VideoEncoderConfig config;
+  test::FillEncoderConfiguration(PayloadStringToCodecType("VP8"), 3, &config);
+  config.video_stream_factory = nullptr;
+  for (size_t i = 0; i < active_layers.size(); ++i) {
+    config.simulcast_layers[i].active = active_layers[i];
+    config.simulcast_layers[i].num_temporal_layers = 1;
+    config.simulcast_layers[i].max_framerate = kDefaultFramerate;
+  }
+  config.max_bitrate_bps = kSimulcastTargetBitrate.bps();
+  config.content_type = VideoEncoderConfig::ContentType::kRealtimeVideo;
+  return config;
+}
+
+size_t CountActiveSpatialLayers(const VideoBitrateAllocation& bitrate,
+                                size_t num_streams) {
+  size_t active_layers = 0;
+  for (size_t i = 0; i < num_streams; ++i) {
+    if (bitrate.GetSpatialLayerSum(i) > 0) {
+      ++active_layers;
+    }
+  }
+  return active_layers;
+}
+
+bool HasAdaptationResourceNamed(
+    const std::vector<scoped_refptr<Resource>>& resources,
+    const char* name) {
+  return absl::c_any_of(resources, [name](const scoped_refptr<Resource>& r) {
+    return r->Name() == name;
+  });
+}
 
 VideoFrame CreateSimpleNV12Frame() {
   return VideoFrame::Builder()
@@ -1126,8 +1161,13 @@ class VideoStreamEncoderTest : public ::testing::Test {
       EncoderInfo info = FakeEncoder::GetEncoderInfo();
       if (initialized_ == EncoderState::kInitialized) {
         if (quality_scaling_) {
-          info.scaling_settings = VideoEncoder::ScalingSettings(
-              kQpLow, kQpHigh, kMinPixelsPerFrame);
+          const bool allow_quality_scaling =
+              !quality_scaling_follows_active_spatial_layers_ ||
+              active_spatial_layers_ <= 1;
+          info.scaling_settings = allow_quality_scaling
+                                      ? VideoEncoder::ScalingSettings(
+                                            kQpLow, kQpHigh, kMinPixelsPerFrame)
+                                      : VideoEncoder::ScalingSettings::kOff;
         }
         info.is_hardware_accelerated = is_hardware_accelerated_;
         for (int i = 0; i < kMaxSpatialLayers; ++i) {
@@ -1170,6 +1210,11 @@ class VideoStreamEncoderTest : public ::testing::Test {
     void SetQualityScaling(bool b) {
       MutexLock lock(&local_mutex_);
       quality_scaling_ = b;
+    }
+
+    void SetQualityScalingFollowsActiveSpatialLayers(bool enabled) {
+      MutexLock lock(&local_mutex_);
+      quality_scaling_follows_active_spatial_layers_ = enabled;
     }
 
     void SetRequestedResolutionAlignment(
@@ -1383,6 +1428,8 @@ class VideoStreamEncoderTest : public ::testing::Test {
     void SetRates(const RateControlParameters& parameters) override {
       MutexLock lock(&local_mutex_);
       num_set_rates_++;
+      active_spatial_layers_ =
+          CountActiveSpatialLayers(parameters.bitrate, kMaxSpatialLayers);
       VideoBitrateAllocation adjusted_rate_allocation;
       for (size_t si = 0; si < kMaxSpatialLayers; ++si) {
         for (size_t ti = 0; ti < kMaxTemporalStreams; ++ti) {
@@ -1413,6 +1460,9 @@ class VideoStreamEncoderTest : public ::testing::Test {
     int last_input_width_ RTC_GUARDED_BY(local_mutex_) = 0;
     int last_input_height_ RTC_GUARDED_BY(local_mutex_) = 0;
     bool quality_scaling_ RTC_GUARDED_BY(local_mutex_) = true;
+    bool quality_scaling_follows_active_spatial_layers_
+        RTC_GUARDED_BY(local_mutex_) = false;
+    size_t active_spatial_layers_ RTC_GUARDED_BY(local_mutex_) = 0;
     uint32_t requested_resolution_alignment_ RTC_GUARDED_BY(local_mutex_) = 1;
     bool apply_alignment_to_all_simulcast_layers_ RTC_GUARDED_BY(local_mutex_) =
         false;
@@ -6827,6 +6877,174 @@ TEST_F(VideoStreamEncoderTest,
   // removed.
   EXPECT_THAT(source.sink_wants(), ResolutionMax());
   EXPECT_FALSE(stats_proxy_->GetStats().bw_limited_resolution);
+
+  video_stream_encoder_->Stop();
+}
+
+TEST_F(VideoStreamEncoderTest,
+       QualityScalerRestrictionsResetWhenActiveLayersIncrease) {
+  // Set up 3-stream simulcast with only the highest layer active (1:1 call).
+  ResetEncoder("VP8", 3, 1, 1, false);
+  fake_encoder_.SetQualityScaling(true);
+  const int kWidth = 1280;
+  const int kHeight = 720;
+
+  video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+      kSimulcastTargetBitrate, kSimulcastTargetBitrate, kSimulcastTargetBitrate,
+      0, 0, 0);
+
+  VideoEncoderConfig config_1_active =
+      Make3LayerVp8SimulcastConfig({false, false, true});
+  video_stream_encoder_->ConfigureEncoder(config_1_active.Copy(),
+                                          kMaxPayloadLength);
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+
+  // Send a frame and trigger quality low to accumulate a resolution adaptation.
+  video_source_.IncomingCapturedFrame(CreateFrame(1, kWidth, kHeight));
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+  video_stream_encoder_->TriggerQualityLow();
+
+  video_source_.IncomingCapturedFrame(CreateFrame(2, kWidth, kHeight));
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+
+  EXPECT_THAT(video_source_.sink_wants(), WantsMaxPixels(Lt(kWidth * kHeight)));
+
+  // Now transition to multi-layer: activate all 3 layers (3rd participant).
+  VideoEncoderConfig video_encoder_config =
+      Make3LayerVp8SimulcastConfig({true, true, true});
+  video_stream_encoder_->ConfigureEncoder(video_encoder_config.Copy(),
+                                          kMaxPayloadLength);
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+  AdvanceTime(TimeDelta::Zero());
+
+  // Quality scaler restrictions should have been cleared on the active-layer
+  // increase so the source can provide full-resolution frames.
+  EXPECT_THAT(video_source_.sink_wants(), ResolutionMax());
+
+  video_stream_encoder_->Stop();
+}
+
+TEST_F(VideoStreamEncoderTest,
+       QualityScalerRestrictionsResetOnTwoToThreeLayerIncrease) {
+  // Set up 3-stream simulcast with 2 layers active.
+  ResetEncoder("VP8", 3, 1, 1, false);
+  fake_encoder_.SetQualityScaling(true);
+  const int kWidth = 1280;
+  const int kHeight = 720;
+
+  video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+      kSimulcastTargetBitrate, kSimulcastTargetBitrate, kSimulcastTargetBitrate,
+      0, 0, 0);
+
+  // Start with 2 active layers.
+  VideoEncoderConfig config_2_active =
+      Make3LayerVp8SimulcastConfig({true, true, false});
+  video_stream_encoder_->ConfigureEncoder(config_2_active.Copy(),
+                                          kMaxPayloadLength);
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+
+  // Send a frame and trigger quality low to accumulate a restriction.
+  video_source_.IncomingCapturedFrame(CreateFrame(1, kWidth, kHeight));
+  WaitForEncodedFrame(1);
+  video_stream_encoder_->TriggerQualityLow();
+
+  video_source_.IncomingCapturedFrame(CreateFrame(2, kWidth, kHeight));
+  WaitForEncodedFrame(2);
+
+  EXPECT_THAT(video_source_.sink_wants(), WantsMaxPixels(Lt(kWidth * kHeight)));
+
+  // Now increase to 3 active layers.
+  VideoEncoderConfig config_3_active =
+      Make3LayerVp8SimulcastConfig({true, true, true});
+  video_stream_encoder_->ConfigureEncoder(config_3_active.Copy(),
+                                          kMaxPayloadLength);
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+  AdvanceTime(TimeDelta::Zero());
+
+  // Restrictions should be cleared on the 2 -> 3 active-layer increase.
+  EXPECT_THAT(video_source_.sink_wants(), ResolutionMax());
+
+  video_stream_encoder_->Stop();
+}
+
+TEST_F(VideoStreamEncoderTest,
+       BandwidthQualityScalerRemovedWhenTransitioningToSimulcast) {
+  fake_encoder_.SetQualityScaling(false);
+  fake_encoder_.SetIsQpTrusted(false);
+
+  VideoEncoderConfig single_layer_config =
+      Make3LayerVp8SimulcastConfig({false, false, true});
+  single_layer_config.is_quality_scaling_allowed = true;
+  ConfigureEncoder(single_layer_config.Copy());
+  video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+      kSimulcastTargetBitrate, kSimulcastTargetBitrate, kSimulcastTargetBitrate,
+      0, 0, 0);
+  video_source_.IncomingCapturedFrame(CreateFrame(1, 1280, 720));
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+
+  EXPECT_TRUE(HasAdaptationResourceNamed(
+      video_stream_encoder_->GetAdaptationResources(),
+      "BandwidthQualityScalerResource"));
+
+  VideoEncoderConfig simulcast_config =
+      Make3LayerVp8SimulcastConfig({true, true, true});
+  simulcast_config.is_quality_scaling_allowed = true;
+  video_stream_encoder_->ConfigureEncoder(simulcast_config.Copy(),
+                                          kMaxPayloadLength);
+  video_stream_encoder_->WaitUntilTaskQueueIsIdle();
+
+  EXPECT_FALSE(HasAdaptationResourceNamed(
+      video_stream_encoder_->GetAdaptationResources(),
+      "BandwidthQualityScalerResource"));
+
+  video_stream_encoder_->Stop();
+}
+
+TEST_F(VideoStreamEncoderTest,
+       QualityScalerResourceTracksRuntimeLayerAllocation) {
+  fake_encoder_.SetQualityScaling(true);
+  fake_encoder_.SetQualityScalingFollowsActiveSpatialLayers(true);
+
+  VideoEncoderConfig simulcast_config =
+      Make3LayerVp8SimulcastConfig({true, true, true});
+  ConfigureEncoder(simulcast_config.Copy());
+  video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+      kSimulcastTargetBitrate, kSimulcastTargetBitrate, kSimulcastTargetBitrate,
+      0, 0, 0);
+  video_source_.IncomingCapturedFrame(CreateFrame(1, 1280, 720));
+  WaitForEncodedFrame(1);
+
+  auto rate_settings = fake_encoder_.GetAndResetLastRateControlSettings();
+  ASSERT_TRUE(rate_settings.has_value());
+  EXPECT_GT(CountActiveSpatialLayers(rate_settings->bitrate,
+                                     simulcast_config.number_of_streams),
+            1u);
+
+  EXPECT_FALSE(HasAdaptationResourceNamed(
+      video_stream_encoder_->GetAdaptationResources(), "QualityScalerResource"));
+
+  const std::array<DataRate, 5> single_layer_rates = {
+      DataRate::KilobitsPerSec(100), DataRate::KilobitsPerSec(150),
+      DataRate::KilobitsPerSec(200), DataRate::KilobitsPerSec(300),
+      DataRate::KilobitsPerSec(500)};
+  bool found_single_layer_rate = false;
+  for (DataRate rate : single_layer_rates) {
+    video_stream_encoder_->OnBitrateUpdatedAndWaitForManagedResources(
+        rate, rate, rate, 0, 0, 0);
+    rate_settings = fake_encoder_.GetAndResetLastRateControlSettings();
+    ASSERT_TRUE(rate_settings.has_value());
+    if (CountActiveSpatialLayers(rate_settings->bitrate,
+                                 simulcast_config.number_of_streams) == 1u) {
+      found_single_layer_rate = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found_single_layer_rate);
+
+  video_source_.IncomingCapturedFrame(CreateFrame(2, 1280, 720));
+  WaitForEncodedFrame(2);
+  EXPECT_TRUE(HasAdaptationResourceNamed(
+      video_stream_encoder_->GetAdaptationResources(), "QualityScalerResource"));
 
   video_stream_encoder_->Stop();
 }

--- a/webrtc.gni
+++ b/webrtc.gni
@@ -562,6 +562,14 @@ template("rtc_test") {
       }
     }
 
+    if (!build_with_chromium && rtc_include_tests &&
+        (!defined(invoker.is_xctest) || !invoker.is_xctest)) {
+      if (!defined(deps)) {
+        deps = []
+      }
+      deps += [ webrtc_root + "test:test_main" ]
+    }
+
     assert(
         !defined(absl_deps),
         "`absl_deps` has been deprecated, add your Abseil dependencies to the `deps` variable.")
@@ -1177,7 +1185,7 @@ if (is_mac || is_ios) {
       deps = [ ":create_bracket_include_headers_$this_target_name" ]
     }
 
-    if (is_mac || target_environment == "catalyst") {
+    if (is_mac) {
       headers_dir = "Versions/A/Headers"
       copy("copy_umbrella_header_$target_name") {
         sources = [ umbrella_header_path ]


### PR DESCRIPTION
# WebRTC Changelog M145 Migration (develop → main)

Source branch: `develop`  
Destination branch: `main`

[Official WebRTC M137..M145 changes](https://webrtc.googlesource.com/src/+log/cec4daea7ed5..b47e68e6966d)  
[Stream release comparison](https://github.com/GetStream/webrtc/compare/main...develop)

This release merges the WebRTC **M145** baseline into `main` from `develop`, on top of the existing Stream fork at **M137**. The upstream integration landed via PR [#81](https://github.com/GetStream/webrtc/pull/81) (`iliaspavlidakis/merge-webrtc-m145` → `develop`); this document covers the combined delta ready for `main`, including post-M145 fork work in [#90](https://github.com/GetStream/webrtc/pull/90).

The upstream WebRTC baseline update contains **2,171 commits by 102 authors**. The Stream-side integration squash touches **20 files**; the full `develop` → `main` delta is **30 files** across the M145 integration and adaptive simulcast enhancement.

## Summary

- **Upstream WebRTC baseline (M137 → M145):** Brings broad changes across media pipelines, transport, PeerConnection/SDP, desktop capture, stats/metrics, security hardening, API cleanup, and build infrastructure—plus 542 Chromium rolls and 130 reverts/relands that move the depot to the M145 snapshot.
- **Media pipeline:** Scream V2 and TWCC/L4S congestion-control work, capture-signal mixing/remixing, NetEq/codec construction without `CodecPairId`, corruption-detection `FrameSelector` trials, AV1/simulcast stability fixes, and frame instrumentation refactors.
- **Transport and PeerConnection:** RTP/RTCP/ICE/DTLS/SCTP updates, DTLS-in-STUN and PQC benchmarking, expanded SDP munging detection, transceiver/channel lifecycle improvements, and `Environment`-based factory construction.
- **Stream SDK and Apple integration:** Preserves ObjC frame crypto, desktop capture bridges, audio device module wiring, Darwin framework/build rules, and CI publish workflows across the new baseline.
- **Frame crypto compatibility:** Aligns C++ and ObjC E2EE paths with upstream buffer and `SetFrameTransformer` APIs.
- **Audio device modernization:** Moves test/native ADM construction to `const Environment&` and `env.task_queue_factory()`.
- **Adaptive simulcast (develop-only, #90):** Extends `SimulcastEncoderAdapter` and `VideoStreamEncoder` resource management for adaptive streaming on top of M145.

## Categories

| Category | Changes |
| --- | ---: |
| Audio | 74 |
| Video and Codecs | 102 |
| Desktop Capture | 27 |
| PeerConnection and SDP | 63 |
| Transport and Networking | 339 |
| Stats and Metrics | 63 |
| Security and Robustness | 24 |
| API and SDK | 3 |
| Tests and Reliability | 108 |
| Build and Infrastructure | 38 |
| Cleanup and Modernization | 245 |
| Reverts and Relands | 130 |
| Rolls and Versioning | 542 |
| General | 413 |

Category counts are based on upstream commit subjects in `webrtc/m137..b47e68e6966d` (`cec4daea7ed5..b47e68e6966d`); routine Chromium rolls and version updates are counted separately so they do not obscure functional changes.

## Upstream WebRTC Highlights

### Audio

- Continues **Scream V2** bandwidth-estimation work: receiver-delay compensation, loss-response fixes, REMB integration, L4S alpha updates, TWCC pairing, traffic policing tests, and crash fixes when replaying BWE scenarios.
- Adds **capture-signal mixing/remixing** infrastructure and related signal-analysis components for capture pipelines.
- Modernizes **NetEq and audio coding** APIs: stricter config validation, `opus_red` payload support in tests, decoder factory helpers, and removal of `AudioCodecPairId` from NetEq surfaces.
- Extends **frame transformer** interfaces with `CaptureTime`, `PayloadType`, and `AudioLevel` setters; allows CSRC configuration on senders.
- Propagates **`Environment` clocks** into Android audio record and related JNI paths.

### Video and Codecs

- Wires **corruption-detection frame selection** through `FrameSelector` (field trials and utility class).
- Improves **codec construction** so codecs/decoders can be created without `CodecPairId`; adds mixed-codec simulcast support in `SimulcastEncoderAdapter`.
- Fixes **AV1 simulcast** timing/scalability handling and strengthens simulcast/integration tests.
- Adds **file-based encoder/decoder** utilities, `VideoFrameSampler`, and software-codec picture-pair helpers for tests and tooling.
- Moves **frame instrumentation** generator implementation toward `video/` and exposes refactored instrumentation data in `api/`.

### Desktop Capture

- Improves capture behavior, including **editor-window capture when slideshow mode** is selected and stronger PowerPoint fullscreen detection tests.
- Updates **Wayland screencast** plumbing (D-Bus unsubscribe, portal behavior, redundant prefix cleanup).
- Adds **FourCC pixel format** support on `DesktopFrame` and **HMONITOR caching** for performance.
- Addresses **ScreencastResult** crash speculation and removes legacy pixel-format checks from frame construction.

### PeerConnection and SDP

- Expands **SDP munging detection** (transceiver direction, SCTP/data-channel fields, restricted candidates, codec preferences, parse failures) with dedicated metrics and unit-test coverage.
- Improves **SCTP/SDP handling**, ICE candidate removal APIs, and transceiver receptive-state modeling.
- Allows injecting a **prebuilt `Environment`** into `PeerConnectionFactory` construction; adds ObjC `setAudioDeviceModuleBuilder`.
- Refactors **RtpTransceiver** and PeerConnection dependency graphs ahead of API slimming.

### Transport and Networking

- Adds **RTP/RTCP send options** (`PacketOptions` on `SendRtcp`), CSRC lists on encodings, and richer `RtpHeaderExtension` stringifiers.
- Improves **DTLS** visibility (version, connection-time metrics) and continues **DTLS-in-STUN / PQC** encapsulation benchmarks and cleanups.
- Advances **Scream + TWCC + L4S** experiments, probing, and integration tests (including RFC 8888 / transport-cc combinations).
- Updates **SCTP/dcSCTP** behavior (pull-mode message consumption, compile-time SCTP guards, error messaging).
- Refactors **jitter estimation**, `RtpToNtpEstimator` placement, and Android ADM creation via injected `Environment`.

### Stats and Metrics

- Adds and fixes **SDP munging outcome** metrics; instruments blocking thread calls in SDP classes.
- Implements **L4S** send/inbound-rtp stats and **RFC 8888** support in parsed event logs.
- Fixes **simulcast stats** gaps for missing `outbound-rtp` entries; adds mixed-codec simulcast stats info.
- Expands **RtcEventLog** driver/examples and RTP transport UMA coverage.

### Security and Robustness

- Adds **SSL error clearing** before `SSL_get_error` and extends certificate verification paths (including chain validation and PQC group reporting).
- Improves **thread-safety** (`RTC_GUARDED_BY`, voice-engine checks, mutex-backed socket picker proxy).
- Fixes crashes in **H265 packetization**, custom SSL verifiers, encoder speed control, and **Scream BWE replay**.
- Tightens **SDP direction validation** and hardens DTLS-in-STUN certificate restrictions.

### Build, Infrastructure, and Cleanup

- Migrates standalone infra toward **Siso/Reclient** (`use_siso=true`, gn logs, bot property updates) and refreshes **DEPS** autorolling (GCS deps, `libpfm4`, fuzzer checkout cleanup).
- Runs broad **GN dependency** and **clang-tidy** hygiene (`modernize-use-std-numbers`, include-cleaner/IWYU sweeps).
- Removes deprecated targets/APIs (`MOCK_METHODn`, legacy field-trial helpers, redundant `webrtc::` qualifiers) across `pc`, `p2p`, `audio`, and tests.
- Large **Chromium roll + WebRTC version bump** volume (542 + 130 reverts/relands) provides the underlying M137→M145 depot movement.

## Stream Integration Highlights

### ObjC SDK and Apple Frameworks

- Preserves Stream's ObjC **frame crypto** APIs across M145:
  - `RTCFrameCryptor`
  - `RTCFrameCryptorKeyProvider`
- Updates **desktop capture** ObjC bridges (`objc_desktop_capture`, `objc_desktop_media_list`) for upstream type/thread API changes.
- Adjusts **native audio device module** entry (`audio_device_module.mm`) for M145 construction patterns.
- Extends **`sdk/BUILD.gn`** and **`webrtc.gni`** for framework exports, test dependencies, and Catalyst/macOS header layout rules.

### Frame Crypto

- Updates `frame_crypto_transformer.cc` buffer handling to use upstream-compatible **`Buffer::CreateUninitializedWithSize`** patterns.
- Adapts ObjC frame cryptor setup to upstream **`SetFrameTransformer`** and modern `webrtc::scoped_refptr` usage while keeping Stream delegate behavior.

### Audio Device

- Updates **`test_audio_device.cc`** and **`audio_state`** paths to use **`const Environment&`** instead of raw `TaskQueueFactory*`.
- Aligns unit tests in `audio_state_unittest.cc` with upstream ADM construction and task-queue access via `env.task_queue_factory()`.

### Desktop Capture

- Refreshes ObjC desktop capture/list headers and implementations for M145 API compatibility (thread creation, typing, and lifecycle).
- Keeps Stream screen/window listing, thumbnail, and frame-delivery behavior while matching upstream style changes.

### Tests

- Hardens **`RTCCameraVideoCapturerTests`** teardown (explicit stop/clear of capture session mocks).
- Reworks **`RTCPeerConnectionFactoryBuilderTest`** to avoid brittle OCMock allocation hooks; uses temporary method replacement for `initWithMediaAndDependencies:` with restoration after each test.
- Updates **`mock_transformable_video_frame.h`** for upstream test API changes.

### CI and Publish Workflows

- Expands **`.github/workflows/manual-platform-tests.yml`** and **`publish.yml`** for M145 validation and release artifact packaging.
- Updates **`prepare-android`** and **`prepare-apple`** composite actions for the new baseline build matrix.

## Additional changes on develop (post-M145 merge)

### Video encoding — adaptive simulcast (#90)

- `66ce11d526cb` **[Enhancement] Extend SimulcastEncoderAdapter to support adaptive streaming (#90)**
- Adds adaptive streaming support in **`SimulcastEncoderAdapter`** with expanded unit coverage.
- Updates **`VideoStreamEncoder`** and **`VideoStreamEncoderResourceManager`** to coordinate layer/resource adaptation under load.
- Adjusts **`encoder_stream_factory`**, **`objc_video_encoder_factory`**, and related tests for the new adaptation behavior.