### PR TITLE
[Fix]AudioEngine transport registration after prepared recording

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1080,6 +1080,7 @@ int32_t AudioEngineDevice::RegisterAudioCallback(AudioTransport* audioCallback) 
       state.output_running = false;
       state.input_enabled = false;
       state.input_running = false;
+      state.input_enabled_persistent_mode = false;
       return state;
     });
     if (stop_result != 0) {

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1336,6 +1336,7 @@ if (is_ios || is_mac) {
             "objc/unittests/RTCMTLVideoView_xctest.m",
             "objc/unittests/RTCMediaConstraintsTest.mm",
             "objc/unittests/RTCNV12TextureCache_xctest.m",
+            "objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm",
             "objc/unittests/RTCPeerConnectionFactoryBuilderTest.mm",
             "objc/unittests/RTCPeerConnectionFactory_xctest.m",
             "objc/unittests/RTCPeerConnectionTest.mm",

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -12,8 +12,14 @@
 
 #include <vector>
 
+#import "api/logging/RTCCallbackLogger.h"
+#import "api/peerconnection/RTCConfiguration.h"
 #import "api/peerconnection/RTCAudioDeviceModule.h"
+#import "api/peerconnection/RTCMediaConstraints.h"
+#import "api/peerconnection/RTCPeerConnection.h"
 #import "api/peerconnection/RTCPeerConnectionFactory.h"
+#import "api/peerconnection/RTCRtpTransceiver.h"
+#import "api/peerconnection/RTCSessionDescription.h"
 #import "components/audio/RTCAudioSession+Private.h"
 
 @interface RTC_OBJC_TYPE(RTCAudioSession)
@@ -88,6 +94,82 @@
   }
 
   retainedAudioDeviceModule = nil;
+}
+
+- (void)testAudioEngineDoesNotDropAudioTransportWhenPreparedBeforeOffer {
+  RTC_OBJC_TYPE(RTCCallbackLogger) *logger =
+      [[RTC_OBJC_TYPE(RTCCallbackLogger) alloc] init];
+  logger.severity = RTCLoggingSeverityWarning;
+  XCTestExpectation *transportFailure =
+      [self expectationWithDescription:@"audio transport registration failure"];
+  transportFailure.inverted = YES;
+  [logger startWithMessageAndSeverityHandler:^(
+              NSString *message, RTCLoggingSeverity severity) {
+    if ([message containsString:
+                     @"Failed to set audio transport since media was active"] ||
+        [message containsString:@"Invalid audio transport"]) {
+      [transportFailure fulfill];
+    }
+  }];
+
+  RTC_OBJC_TYPE(RTCPeerConnectionFactory) *factory =
+      [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc]
+          initWithAudioDeviceModuleType:
+              RTC_OBJC_TYPE(RTCAudioDeviceModuleTypeAudioEngine)
+                    bypassVoiceProcessing:NO
+                           encoderFactory:nil
+                           decoderFactory:nil
+                    audioProcessingModule:nil];
+  RTC_OBJC_TYPE(RTCAudioDeviceModule) *audioDeviceModule =
+      factory.audioDeviceModule;
+  XCTAssertEqual(0, [audioDeviceModule setRecordingAlwaysPreparedMode:YES]);
+  XCTAssertTrue(audioDeviceModule.recordingAlwaysPreparedMode);
+
+  RTC_OBJC_TYPE(RTCConfiguration) *config =
+      [[RTC_OBJC_TYPE(RTCConfiguration) alloc] init];
+  config.sdpSemantics = RTCSdpSemanticsUnifiedPlan;
+  RTC_OBJC_TYPE(RTCMediaConstraints) *constraints =
+      [[RTC_OBJC_TYPE(RTCMediaConstraints) alloc]
+          initWithMandatoryConstraints:@{
+            RTC_CONSTANT_TYPE(RTCMediaConstraintsOfferToReceiveAudio) :
+                RTC_CONSTANT_TYPE(RTCMediaConstraintsValueTrue)
+          }
+                   optionalConstraints:nil];
+  RTC_OBJC_TYPE(RTCPeerConnection) *peerConnection =
+      [factory peerConnectionWithConfiguration:config
+                                   constraints:constraints
+                                      delegate:nil];
+  RTC_OBJC_TYPE(RTCRtpTransceiverInit) *transceiverInit =
+      [[RTC_OBJC_TYPE(RTCRtpTransceiverInit) alloc] init];
+  transceiverInit.direction = RTCRtpTransceiverDirectionRecvOnly;
+  XCTAssertNotNil([peerConnection addTransceiverOfType:RTCRtpMediaTypeAudio
+                                                  init:transceiverInit]);
+
+  dispatch_semaphore_t offerSemaphore = dispatch_semaphore_create(0);
+  __block RTC_OBJC_TYPE(RTCSessionDescription) *localOffer = nil;
+  __block NSError *localOfferError = nil;
+  [peerConnection
+      offerForConstraints:constraints
+        completionHandler:^(
+            RTC_OBJC_TYPE(RTCSessionDescription) *_Nullable offer,
+            NSError *_Nullable error) {
+          localOffer = offer;
+          localOfferError = error;
+          dispatch_semaphore_signal(offerSemaphore);
+        }];
+  XCTAssertEqual(
+      0,
+      dispatch_semaphore_wait(
+          offerSemaphore,
+          dispatch_time(DISPATCH_TIME_NOW, (int64_t)(15 * NSEC_PER_SEC))));
+  XCTAssertNil(localOfferError);
+  XCTAssertNotNil(localOffer);
+
+  [self waitForExpectations:@[ transportFailure ] timeout:1.0];
+
+  [peerConnection close];
+  XCTAssertEqual(0, [audioDeviceModule setRecordingAlwaysPreparedMode:NO]);
+  [logger stop];
 }
 
 @end


### PR DESCRIPTION
## What's the issue

When `AudioEngineDevice` has recording prepared before WebRTC registers its audio transport, `RegisterAudioCallback` tries to restart the active audio buffer but does not fully disable persistent recording state.

That leaves `AudioDeviceBuffer` active, so the transport registration is rejected with:

`Failed to set audio transport since media was active`

After that, the audio I/O thread repeatedly logs:

`Invalid audio transport`

In this state, recorded audio cannot be delivered to WebRTC and playout cannot request audio from WebRTC, causing both sending and receiving audio to fail.

## What's the fix

Clear `input_enabled_persistent_mode` during the temporary stop inside `AudioEngineDevice::RegisterAudioCallback`.

This lets the audio buffer fully stop before registering the WebRTC audio transport. After registration, the previous engine state is restored as before.

A new iOS `sdk_unittests` test reproduces the real flow with an AudioEngine-backed `RTCPeerConnectionFactory`, `recordingAlwaysPreparedMode`, audio transceiver creation, and offer generation.

## Manual steps to reproduce the issue

Before the fix:

1. Use an AudioEngine-backed WebRTC factory.
2. Enable recording-always-prepared mode before creating/negotiating audio.
3. Create a peer connection with an audio transceiver and generate an offer.
4. Observe logs containing:
   - `RegisterAudioCallback while active. Restarting audio buffer.`
   - `Failed to set audio transport since media was active`
   - repeated `Invalid audio transport`
5. Audio send/receive does not work.

After the fix:

1. Repeat the same setup.
2. Create a peer connection with an audio transceiver and generate an offer.
3. `RegisterAudioCallback` still restarts the audio buffer, but transport registration succeeds.
4. The logs no longer contain `Failed to set audio transport since media was active` or repeated `Invalid audio transport`.
5. Audio send/receive works.

## Change risk

Low to medium.

The code change is small and scoped to the restart path used when audio transport registration happens while the AudioEngine buffer is already active. The main risk is unintended behavior during AudioEngine state restoration after callback registration, especially for prepared-recording or muted-speech-detection flows. The new regression test covers the failing registration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio transport handling to properly reset persistent input-enabled mode during audio callback changes when playback or recording is active.

* **Tests**
  * Added test coverage for audio engine behavior during peer connection offer preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/webrtc/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->