### PR TITLE
[Fix]AudioEngine teardown crash

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -99,8 +99,16 @@ enum AudioEngineErrorCode {
 };
 
 class FineAudioBuffer;
+class AudioEngineDeviceInputRenderContext;
 
 extern NSString* const kAudioEngineInputMixerNodeKey;
+
+// Test hook for the AVAudioSinkNode lifetime regression. Keep the actual render context private to
+// audio_engine_device.mm so this header does not grow extra implementation surface just for tests.
+OSStatus AudioEngineDeviceRenderInvalidatedInputContextForTesting(
+    const AudioTimeStamp* timestamp,
+    AVAudioFrameCount frame_count,
+    const AudioBufferList* input_data);
 
 class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver {
  public:
@@ -491,7 +499,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   const std::unique_ptr<TaskQueueFactory> task_queue_factory_;
   std::unique_ptr<AudioDeviceBuffer> audio_device_buffer_;
-  std::unique_ptr<FineAudioBuffer> fine_audio_buffer_;
+  std::shared_ptr<FineAudioBuffer> fine_audio_buffer_;
 
   AudioParameters playout_parameters_;
   AudioParameters record_parameters_;
@@ -527,10 +535,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   // Input related nodes
   AVAudioSinkNode* sink_node_ RTC_GUARDED_BY(thread_);
   AVAudioMixerNode* input_mixer_node_ RTC_GUARDED_BY(thread_);
-
-  // Float32 -> Int16 converter.
-  AudioConverterRef converter_ref_;
-  AVAudioPCMBuffer* converter_buffer_;
+  std::shared_ptr<AudioEngineDeviceInputRenderContext> input_render_context_
+      RTC_GUARDED_BY(thread_);
 
   void* configuration_observer_ RTC_GUARDED_BY(thread_);
 };

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -21,6 +21,7 @@
 
 #include <mach/mach_time.h>
 #include <cmath>
+#include <utility>
 
 #include "api/array_view.h"
 #include "api/environment/environment_factory.h"
@@ -59,6 +60,119 @@ const useconds_t kStartEngineRetryDelayMs = 100;
 
 const size_t kMaximumFramesPerBuffer = 3072;
 const size_t kAudioSampleSize = 2;  // Signed 16-bit integer
+
+// Private context captured by the AVAudioSinkNode receiver block. The important invariant is that
+// graph teardown invalidates this object before detaching/releasing the sink node, but the block's
+// shared_ptr keeps the converter, PCM buffer, and FineAudioBuffer alive until any late AURemoteIO
+// callback returns.
+class AudioEngineDeviceInputRenderContext {
+ public:
+  AudioEngineDeviceInputRenderContext(std::shared_ptr<FineAudioBuffer> fine_audio_buffer,
+                                      AudioConverterRef converter_ref,
+                                      AVAudioPCMBuffer* converter_buffer,
+                                      double mach_tick_units_to_nanoseconds);
+  ~AudioEngineDeviceInputRenderContext();
+
+  void Invalidate();
+  OSStatus Render(const AudioTimeStamp* timestamp,
+                  AVAudioFrameCount frame_count,
+                  const AudioBufferList* input_data);
+
+ private:
+  std::atomic<bool> active_{true};
+  std::shared_ptr<FineAudioBuffer> fine_audio_buffer_;
+  AudioConverterRef converter_ref_;
+  __strong AVAudioPCMBuffer* converter_buffer_;
+  const double mach_tick_units_to_nanoseconds_;
+};
+
+AudioEngineDeviceInputRenderContext::AudioEngineDeviceInputRenderContext(
+    std::shared_ptr<FineAudioBuffer> fine_audio_buffer,
+    AudioConverterRef converter_ref,
+    AVAudioPCMBuffer* converter_buffer,
+    double mach_tick_units_to_nanoseconds)
+    : fine_audio_buffer_(std::move(fine_audio_buffer)),
+      converter_ref_(converter_ref),
+      converter_buffer_(converter_buffer),
+      mach_tick_units_to_nanoseconds_(mach_tick_units_to_nanoseconds) {}
+
+AudioEngineDeviceInputRenderContext::~AudioEngineDeviceInputRenderContext() {
+  if (converter_ref_ != nullptr) {
+    OSStatus err = AudioConverterDispose(converter_ref_);
+    RTC_DCHECK(err == noErr);
+    converter_ref_ = nullptr;
+  }
+}
+
+void AudioEngineDeviceInputRenderContext::Invalidate() {
+  active_.store(false, std::memory_order_release);
+}
+
+OSStatus AudioEngineDeviceInputRenderContext::Render(
+    const AudioTimeStamp* timestamp,
+    AVAudioFrameCount frame_count,
+    const AudioBufferList* input_data) {
+  // AVAudioEngine may deliver one final sink callback after graph teardown has begun. In that
+  // window the owning AudioEngineDevice has already requested invalidation, but this context stays
+  // alive because the block captured a shared_ptr. Return noErr so the realtime thread exits
+  // quietly without touching converter state that teardown is allowed to retire.
+  if (!active_.load(std::memory_order_acquire)) {
+    return noErr;
+  }
+
+  if (timestamp == nullptr || input_data == nullptr || input_data->mNumberBuffers == 0 ||
+      converter_ref_ == nullptr || converter_buffer_ == nil || fine_audio_buffer_ == nullptr) {
+    return noErr;
+  }
+
+  RTC_DCHECK(input_data->mNumberBuffers == 1);
+
+  AudioBufferList* converter_buffer_abl =
+      const_cast<AudioBufferList*>(converter_buffer_.audioBufferList);
+  if (converter_buffer_abl == nullptr || converter_buffer_abl->mNumberBuffers == 0) {
+    return noErr;
+  }
+
+  RTC_DCHECK(converter_buffer_abl->mNumberBuffers == input_data->mNumberBuffers);
+
+  // Fails for conversions where there is a variation between the input and output data
+  // buffer sizes.
+  converter_buffer_abl->mBuffers[0].mDataByteSize = input_data->mBuffers[0].mDataByteSize;
+
+  RTC_DCHECK(converter_buffer_abl->mBuffers[0].mDataByteSize ==
+             input_data->mBuffers[0].mDataByteSize);
+
+  OSStatus err =
+      AudioConverterConvertComplexBuffer(converter_ref_, frame_count, input_data,
+                                         converter_buffer_abl);
+  RTC_DCHECK(err == noErr);
+  if (err != noErr) {
+    return err;
+  }
+
+  const int16_t* rtc_buffer = (int16_t*)converter_buffer_abl->mBuffers[0].mData;  // Float32
+  if (rtc_buffer == nullptr) {
+    return noErr;
+  }
+
+  const int64_t capture_time_ns =
+      timestamp->mHostTime * mach_tick_units_to_nanoseconds_;
+
+  fine_audio_buffer_->DeliverRecordedData(
+      webrtc::ArrayView<const int16_t>(rtc_buffer, frame_count), kFixedRecordDelayEstimate,
+      capture_time_ns);
+
+  return noErr;
+}
+
+OSStatus AudioEngineDeviceRenderInvalidatedInputContextForTesting(
+    const AudioTimeStamp* timestamp,
+    AVAudioFrameCount frame_count,
+    const AudioBufferList* input_data) {
+  auto context = std::make_shared<AudioEngineDeviceInputRenderContext>(nullptr, nullptr, nil, 1.0);
+  context->Invalidate();
+  return context->Render(timestamp, frame_count, input_data);
+}
 
 AudioEngineDevice::AudioEngineDevice(bool voice_processing_bypassed)
     : task_queue_factory_(CreateDefaultTaskQueueFactory()), initialized_(false) {
@@ -1955,6 +2069,15 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
         return rollback(result);
       }
     }
+
+    // Engine recreation skips the normal input-disable branch below. Invalidate the sink context
+    // here so a late input callback from the old graph exits before touching the converter/buffer
+    // that belong to that graph.
+    if (input_render_context_ != nullptr) {
+      input_render_context_->Invalidate();
+      input_render_context_.reset();
+    }
+
     engine_device_ = nil;
   }
 
@@ -2226,50 +2349,38 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     audio_device_buffer_->SetRecordingSampleRate(rtc_input_format.sampleRate);
     audio_device_buffer_->SetRecordingChannels(rtc_input_format.channelCount);
     RTC_DCHECK(audio_device_buffer_ != nullptr);
-    fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
+    fine_audio_buffer_ = std::make_shared<FineAudioBuffer>(audio_device_buffer_.get());
 
     // Prepare Float32 -> Int16 converter.
-    if (converter_ref_ == nullptr) {
-      OSStatus err = AudioConverterNew(engine_input_format.streamDescription,
-                                       rtc_input_format.streamDescription, &converter_ref_);
-      RTC_DCHECK(err == noErr);
+    AudioConverterRef converter_ref = nullptr;
+    OSStatus converter_err = AudioConverterNew(engine_input_format.streamDescription,
+                                               rtc_input_format.streamDescription, &converter_ref);
+    RTC_DCHECK(converter_err == noErr);
+    if (converter_err != noErr) {
+      return rollback(kAudioEngineRecordingInitError);
     }
 
     // Prepare buffer for Int16 converter.
-    if (converter_buffer_ == nil) {
-      converter_buffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:rtc_input_format
-                                                        frameCapacity:kMaximumFramesPerBuffer];
+    AVAudioPCMBuffer* converter_buffer =
+        [[AVAudioPCMBuffer alloc] initWithPCMFormat:rtc_input_format
+                                      frameCapacity:kMaximumFramesPerBuffer];
+    if (converter_buffer == nil) {
+      AudioConverterDispose(converter_ref);
+      return rollback(kAudioEngineOutOfMemoryError);
     }
+
+    // The sink block used to read converter_ref_, converter_buffer_, and fine_audio_buffer_
+    // directly from AudioEngineDevice. RegisterAudioCallback can now perform a full input stop
+    // while AVAudioEngine still has one callback in flight, so those members can disappear under
+    // the realtime thread. Keep all three inside a block-captured context instead.
+    auto input_render_context = std::make_shared<AudioEngineDeviceInputRenderContext>(
+        fine_audio_buffer_, converter_ref, converter_buffer, machTickUnitsToNanoseconds_);
 
     // Convert to Int16 buffers within the sink block.
     AVAudioSinkNodeReceiverBlock sink_block =
         ^OSStatus(const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount,
                   const AudioBufferList* inputData) {
-          RTC_DCHECK(inputData->mNumberBuffers == 1);
-
-          AudioBufferList* converter_buffer_abl =
-              const_cast<AudioBufferList*>(converter_buffer_.audioBufferList);
-          RTC_DCHECK(converter_buffer_abl->mNumberBuffers == inputData->mNumberBuffers);
-
-          // Fails for conversions where there is a variation between the input and output data
-          // buffer sizes.
-          converter_buffer_abl->mBuffers[0].mDataByteSize = inputData->mBuffers[0].mDataByteSize;
-
-          RTC_DCHECK(converter_buffer_abl->mBuffers[0].mDataByteSize ==
-                     inputData->mBuffers[0].mDataByteSize);
-
-          OSStatus err = AudioConverterConvertComplexBuffer(converter_ref_, frameCount, inputData,
-                                                            converter_buffer_abl);
-          RTC_DCHECK(err == noErr);
-
-          const int16_t* rtc_buffer = (int16_t*)converter_buffer_abl->mBuffers[0].mData;  // Float32
-          const int64_t capture_time_ns = timestamp->mHostTime * machTickUnitsToNanoseconds_;
-
-          fine_audio_buffer_->DeliverRecordedData(
-              webrtc::ArrayView<const int16_t>(rtc_buffer, frameCount), kFixedRecordDelayEstimate,
-              capture_time_ns);
-
-          return noErr;
+          return input_render_context->Render(timestamp, frameCount, inputData);
         };
 
     NSMutableArray<AVAudioConnectionPoint*>* input_mixer_connections = [NSMutableArray array];
@@ -2302,6 +2413,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     }
 
     sink_node_ = [[AVAudioSinkNode alloc] initWithReceiverBlock:sink_block];
+    input_render_context_ = input_render_context;
     [engine_device_ attachNode:sink_node_];
 
     [engine_device_ connect:input_mixer_node_ to:sink_node_ format:engine_input_format];
@@ -2315,6 +2427,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     if (inputNode().voiceProcessingEnabled && inputNode().voiceProcessingInputMuted) {
       LOGI() << "Update mute (voice processing) unmuting vp for stop-recording";
       inputNode().voiceProcessingInputMuted = false;
+    }
+
+    if (input_render_context_ != nullptr) {
+      input_render_context_->Invalidate();
     }
 
     // Detach input mixer node
@@ -2344,16 +2460,7 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
         sink_node_ = nil;
       }
     }
-
-    // Dispose Float32 -> Int16 converter.
-    if (converter_ref_ != nullptr) {
-      OSStatus err = AudioConverterDispose(converter_ref_);
-      RTC_DCHECK(err == noErr);
-      converter_ref_ = nullptr;
-    }
-
-    // Release buffer for Int16 converter.
-    converter_buffer_ = nil;
+    input_render_context_.reset();
   }
 
   // --------------------------------------------------------------------------------------------

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -21,6 +21,7 @@
 #import "api/peerconnection/RTCRtpTransceiver.h"
 #import "api/peerconnection/RTCSessionDescription.h"
 #import "components/audio/RTCAudioSession+Private.h"
+#include "modules/audio_device/audio_engine_device.h"
 
 @interface RTC_OBJC_TYPE(RTCAudioSession)
 (UnitTesting)
@@ -170,6 +171,27 @@
   [peerConnection close];
   XCTAssertEqual(0, [audioDeviceModule setRecordingAlwaysPreparedMode:NO]);
   [logger stop];
+}
+
+- (void)testAudioEngineInputRenderContextIgnoresLateCallbackAfterInvalidation {
+  // This is a focused regression test for the crash where AURemoteIO invoked the AVAudioSinkNode
+  // receiver block after AudioEngineDevice had already torn down its converter buffer during the
+  // RegisterAudioCallback stop/restart path. The test intentionally does not require real audio
+  // hardware: a late callback after invalidation must return cleanly before it touches resources
+  // that graph teardown is allowed to clear.
+  int16_t sample = 0;
+  AudioBufferList inputData;
+  inputData.mNumberBuffers = 1;
+  inputData.mBuffers[0].mNumberChannels = 1;
+  inputData.mBuffers[0].mDataByteSize = sizeof(sample);
+  inputData.mBuffers[0].mData = &sample;
+
+  AudioTimeStamp timestamp = {};
+  timestamp.mHostTime = 1;
+
+  XCTAssertEqual(noErr,
+                 webrtc::AudioEngineDeviceRenderInvalidatedInputContextForTesting(
+                     &timestamp, 1, &inputData));
 }
 
 @end


### PR DESCRIPTION
### 🎯 Goal

Fix an iOS `AVAudioEngine` input teardown crash where `AURemoteIO::IOThread` can invoke a late `AVAudioSinkNode` callback after `AudioEngineDevice` has already started tearing down input resources.

### 📝 Summary

- Fixes a crash in the AudioEngine input sink callback during recording/input teardown.
- Keeps the existing `RegisterAudioCallback` stop/restart behavior unchanged.
- Moves input render callback resources into a block-captured context.
- Ensures the converter, converter buffer, and `FineAudioBuffer` stay alive until any in-flight sink callback returns.
- Adds a regression test for a late callback after input render context invalidation.

### 🛠 Implementation

`RegisterAudioCallback` can temporarily stop and restart AudioEngine while input is active. During that stop path, input can be disabled, the sink node detached, and input conversion resources retired while `AVAudioEngine` may still deliver a final callback on `AURemoteIO::IOThread`.

Previously, the sink block accessed `AudioEngineDevice` members directly. A late callback could therefore read released converter or audio buffer state.

This PR introduces an input-only render context captured by the `AVAudioSinkNode` block. Teardown invalidates the context before detaching/releasing the input graph, while the block-held `shared_ptr` keeps callback resources alive until the callback returns. The callback returns `noErr` if it observes an invalidated context.

The change is intentionally scoped to the input sink path and does not change the output/source node behavior.

Validated with the iOS test lane:

```bash
PATH="/Users/ipavlidakis/workspace/webrtc/depot_tools:$PATH" \
bundle exec fastlane ios test \
  root:/Users/ipavlidakis/workspace/webrtc/src \
  targets:"sdk_unittests" \
  verbose:true
```

Result:

- `sdk_unittests`: `182 tests, 0 failures`
- `TEST EXECUTE SUCCEEDED`
- Regression test passed:
  - `testAudioEngineInputRenderContextIgnoresLateCallbackAfterInvalidation`

Also built a local iOS `StreamWebRTC.xcframework` with dSYMs and validated matching UUIDs.

### 🧪 Manual Testing Notes

- Join a call
- leave while the call is joining
- repeat a few times back to back

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (tutorial, CMS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of audio input handling during engine lifecycle changes to prevent late callbacks from accessing stale data.

* **Tests**
  * Added test coverage for audio input rendering in edge-case scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/webrtc/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->