### PR TITLE
[Fix]AddTransceiver after PeerConnection close

### DIFF
--- a/pc/peer_connection.cc
+++ b/pc/peer_connection.cc
@@ -1120,6 +1120,14 @@ PeerConnection::AddTransceiver(MediaType media_type,
     LOG_AND_RETURN_ERROR(RTCErrorType::UNSUPPORTED_OPERATION,
                          "Not configured for media");
   }
+  // In m146, AddTransceiver creates audio/video channels while constructing the
+  // transceiver. If Close() has already reset call_, continuing past this point
+  // can pass PeerConnection::call_ptr_ (a known raw-pointer workaround) into the
+  // channel constructors and crash when they dereference Call.
+  if (IsClosed()) {
+    LOG_AND_RETURN_ERROR(RTCErrorType::INVALID_STATE,
+                         "PeerConnection is closed.");
+  }
   RTC_DCHECK(
       (media_type == MediaType::AUDIO || media_type == MediaType::VIDEO));
   if (track) {

--- a/pc/peer_connection_rtp_unittest.cc
+++ b/pc/peer_connection_rtp_unittest.cc
@@ -984,6 +984,20 @@ TEST_F(PeerConnectionRtpTestUnifiedPlan,
   EXPECT_EQ(MediaStreamTrackInterface::TrackState::kLive, track->state());
 }
 
+TEST_F(PeerConnectionRtpTestUnifiedPlan,
+       AddAudioTransceiverAfterCloseReturnsInvalidState) {
+  auto caller = CreatePeerConnection();
+  caller->pc()->Close();
+
+  // Regression coverage for the m146 channel-creation path: AddTransceiver now
+  // constructs media channels early, and doing that after Close() used to reach
+  // PeerConnection::call_ptr_ after call_ had been reset on the worker thread.
+  auto result = caller->pc()->AddTransceiver(MediaType::AUDIO);
+
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ(RTCErrorType::INVALID_STATE, result.error().type());
+}
+
 // Test that adding a transceiver with the video kind creates an video sender
 // and video receiver with the receiver having a live video track.
 TEST_F(PeerConnectionRtpTestUnifiedPlan,


### PR DESCRIPTION
### 🎯 Goal

Fix a crash introduced by the m145/m146 migration where `AddTransceiver` can still create audio media channels after `PeerConnection::Close()` has already started tearing down the underlying `Call`.

This was not reproducible on the previous m137-based builds. The newer m145/m146 code path creates media channels earlier, during `RtpTransceiver` construction, which exposes a stale `Call*` access if app-level call teardown races with pending renegotiation or transceiver creation.

We observed this on iOS because the SDK caches one call object per CID. During a rapid leave/rejoin cycle, the cached call can be reused while the previous leave is still tearing down the underlying `PeerConnection`. That can trigger `AddTransceiver` after `PeerConnection::Close()`. Android does not reproduce the same flow because it does not reuse a cached call instance for the same CID, so rejoin creates fresh call state instead of racing the closing `PeerConnection`.

### 📝 Summary

- Prevents `AddTransceiver` from creating media channels after `PeerConnection` is closed.
- Returns `INVALID_STATE` instead of continuing into transceiver/channel construction.
- Avoids dereferencing `PeerConnection::call_ptr_` after `call_` has been reset on the worker thread.
- Adds a platform-agnostic regression test for `AddTransceiver(MediaType::AUDIO)` after close.
- Keeps the fix scoped to the public `AddTransceiver` closed-state behavior.

### 🛠 Implementation

In m137, audio/video media channel creation happened later through `RtpTransceiver::CreateChannel(...)`.

After the m145/m146 migration, `RtpTransceiver` can create media channels during construction:

```cpp
context_->worker_thread()->BlockingCall([&]() mutable {
  auto channels = CreateMediaContentChannels(
      media_type_, env_, media_engine(), call, media_config, audio_options,
      video_options, crypto_options, video_bitrate_allocator_factory);
```

That means `PeerConnection::AddTransceiver(...)` can synchronously reach `WebRtcVoiceSendChannel` construction. The crash happens because `WebRtcVoiceSendChannel` immediately dereferences the `Call*`:

```cpp
WebRtcVoiceSendChannel::WebRtcVoiceSendChannel(...)
    : MediaChannelUtil(call->network_thread(), config.enable_dscp),
```

If `PeerConnection::Close()` has already reset `call_` on the worker thread, the raw `PeerConnection::call_ptr_` can be stale. WebRTC already calls out this risk in `PeerConnection`:

```cpp
// Points to the same thing as `call_`. Since it's const, we may read the
// pointer from any thread.
// TODO(...): Remove this workaround (and potential dangling pointer).
Call* const call_ptr_;
```

This PR adds an `IsClosed()` guard in the shared `PeerConnection::AddTransceiver(...)` implementation before reaching `RtpTransmissionManager::CreateAndAddTransceiver`. This mirrors existing closed-state behavior in APIs like `AddTrack` and returns `RTCErrorType::INVALID_STATE` instead of allowing channel creation to proceed with a stale `Call*`.

Validated with the iOS test lane because the crash was observed in the iOS SDK flow:

```bash
PATH="/Users/ipavlidakis/workspace/webrtc/depot_tools:$PATH" \
bundle exec fastlane ios test \
  root:/Users/ipavlidakis/workspace/webrtc/src \
  targets:"peerconnection_unittests" \
  extra_args:"--gtest_filter=PeerConnectionRtpTestUnifiedPlan.AddAudioTransceiverAfterCloseReturnsInvalidState" \
  verbose:true
```

Result:

- `PeerConnectionRtpTestUnifiedPlan.AddAudioTransceiverAfterCloseReturnsInvalidState` passed.
- `TEST EXECUTE SUCCEEDED`.

### 🧪 Manual Testing Notes

- Join a call
- while joining hang up
- repeat a few times back to back
- no crash should be observed

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] This change follows zero ⚠️ policy (required)
- [x] This change should receive manual QA
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests