### PR TITLE
[Fix] Expose missing headers in the macOS framework

### DIFF
--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1796,6 +1796,13 @@ if (is_ios || is_mac) {
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
           "objc/helpers/RTCYUVHelper.h",
+          "objc/components/video_codec/RTCVideoEncoderFactorySimulcast.h",
+          "objc/api/video_codec/RTCVideoEncoderSimulcast.h",
+          "objc/components/audio/RTCAudioBuffer.h",
+          "objc/components/audio/RTCAudioProcessingModule.h",
+          "objc/components/audio/RTCDefaultAudioProcessingModule.h",
+          "objc/components/audio/RTCAudioCustomProcessingDelegate.h",
+          "objc/components/audio/RTCAudioProcessingConfig.h",
         ]
         if (!build_with_chromium) {
           sources += [
@@ -1813,6 +1820,7 @@ if (is_ios || is_mac) {
           ":native_api",
           ":native_video",
           ":peerconnectionfactory_base_objc",
+          ":simulcast",
           ":videocapture_objc",
           ":videocodec_objc",
           ":videotoolbox_objc",

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1795,6 +1795,7 @@ if (is_ios || is_mac) {
           "objc/components/video_codec/RTCVideoEncoderH264.h",
           "objc/components/video_frame_buffer/RTCCVPixelBuffer.h",
           "objc/helpers/RTCDispatcher.h",
+          "objc/helpers/RTCYUVHelper.h",
         ]
         if (!build_with_chromium) {
           sources += [


### PR DESCRIPTION
## Summary
  
- Adds `RTCYUVHelper.h`, `RTCVideoEncoderFactorySimulcast.h`, `RTCVideoEncoderSimulcast.h`, and the audio-processing headers (`RTCAudioBuffer`, `RTCAudioProcessingModule`, `RTCDefaultAudioProcessingModule`, `RTCAudioCustomProcessingDelegate`, `RTCAudioProcessingConfig`) to `mac_framework_objc` sources in `sdk/BUILD.gn`, alongside their existing iOS counterparts in `framework_objc`.
- Adds `:simulcast` to `mac_framework_objc` deps so the simulcast `.mm` implementations are linked into the macOS binary (the audio-processing implementations are already pulled in transitively via `:peerconnectionfactory_base_objc`).

 ## Motivation

Migrating `stream_webrtc_flutter` macOS to support Swift Package Manager with the newest WebRTC build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS SDK framework to include additional video encoding and audio processing components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/webrtc/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->