### PR TITLE
fix(ios): reattach speech-activity listener after engine start

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -2577,6 +2577,10 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
                       }
                     }];
 
+        // engine.start() drops the muted-talker listener; re-arm it on the live input node.
+        if (state.next.IsInputEnabled() && inputNode().voiceProcessingEnabled) {
+          ConfigureMutedSpeechActivityEventListener(inputNode(), state);
+        }
       } else {
         LOGE() << "Failed to start engine after " << kStartEngineMaxRetries << " attempts";
         DebugAudioEngine();


### PR DESCRIPTION
## Bug

Speech-activity events  stop firing on iOS, even with voice processing on and the mic muted via voiceProcessingInputMuted.

## Cause

The listener is installed only inside ConfigureVoiceProcessingNode, behind a voice-processing enable transition. engine.start() rebuilds the VP audio unit and drops the listener, and the transition never fires again once VP stays enabled. So the listener is alive only between install and the first start, then dead for the rest of the session.

## Fix

Reattach the listener right after a successful engine.start(), in the if (start_result) block of ApplyDeviceEngineState. This block runs on every start / restart / recreate / interruption recovery (and route changes via ReconfigureEngine), so the listener stays bound to the live input node. Re-installing is idempotent, and the pre-start install is left untouched.

## Tested

Built `WebRTC.xcframework` and tested with react-native dogfood sample 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where audio input event listeners were being incorrectly dropped during audio engine initialization, ensuring voice processing functions correctly when input is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->