### PR TITLE
Guard AVAudioEngine connect calls against transient invalid formats

### DIFF
--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1789,9 +1789,14 @@ int32_t AudioEngineDevice::ApplyManualEngineState(EngineStateUpdate& state) {
       }
     }
 
-    [engine_manual_input_ connect:engine_manual_input_.mainMixerNode
-                               to:outputNode()
-                           format:manual_render_rtc_format_];
+    @try {
+      [engine_manual_input_ connect:engine_manual_input_.mainMixerNode
+                                 to:outputNode()
+                             format:manual_render_rtc_format_];
+    } @catch (NSException* exception) {
+      LOGE() << "Failed to connect manual input nodes: " << exception.reason.UTF8String;
+      return kAudioEngineDeviceFormatError;
+    }
 
   } else if (state.prev.IsInputEnabled() && !state.next.IsInputEnabled()) {
     LOGI() << "Disabling input for AVAudioEngine...";
@@ -2121,15 +2126,20 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
                                                  renderBlock:source_block];
     [engine_device_ attachNode:source_node_];
 
-    [engine_device_ connect:source_node_
-                         to:engine_device_.mainMixerNode
-                     format:engine_output_format];
+    @try {
+      [engine_device_ connect:source_node_
+                           to:engine_device_.mainMixerNode
+                       format:engine_output_format];
 
-    // mainMixerNode -> outputNode is connected by default by AVAudioEngine, but we connect anyways
-    // with format.
-    [engine_device_ connect:engine_device_.mainMixerNode
-                         to:outputNode()
-                     format:engine_output_format];
+      // mainMixerNode -> outputNode is connected by default by AVAudioEngine, but we connect anyways
+      // with format.
+      [engine_device_ connect:engine_device_.mainMixerNode
+                           to:outputNode()
+                       format:engine_output_format];
+    } @catch (NSException* exception) {
+      LOGE() << "Failed to connect output nodes: " << exception.reason.UTF8String;
+      return rollback(kAudioEngineDeviceFormatError);
+    }
 
     // Confirm the mixer honored our channel count
     AVAudioFormat* mixer_format = [engine_device_.mainMixerNode outputFormatForBus:0];
@@ -2295,16 +2305,26 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     }
 
     LOGI() << "input mixer connection count: " << input_mixer_connections.count;
-    if (input_mixer_connections.count == 0) {
-      LOGI() << "Nothing connected to input mixer, connecting input node...";
-      // Default implementation.
-      [engine_device_ connect:inputNode() to:input_mixer_node_ format:engine_input_format];
+    @try {
+      if (input_mixer_connections.count == 0) {
+        LOGI() << "Nothing connected to input mixer, connecting input node...";
+        // Default implementation.
+        [engine_device_ connect:inputNode() to:input_mixer_node_ format:engine_input_format];
+      }
+    } @catch (NSException* exception) {
+      LOGE() << "Failed to connect input nodes: " << exception.reason.UTF8String;
+      return rollback(kAudioEngineDeviceFormatError);
     }
 
     sink_node_ = [[AVAudioSinkNode alloc] initWithReceiverBlock:sink_block];
     [engine_device_ attachNode:sink_node_];
 
-    [engine_device_ connect:input_mixer_node_ to:sink_node_ format:engine_input_format];
+    @try {
+      [engine_device_ connect:input_mixer_node_ to:sink_node_ format:engine_input_format];
+    } @catch (NSException* exception) {
+      LOGE() << "Failed to connect input mixer to sink node: " << exception.reason.UTF8String;
+      return rollback(kAudioEngineDeviceFormatError);
+    }
 
   } else if ((state.prev.IsInputEnabled() && !state.next.IsInputEnabled()) &&
              !state.IsEngineRecreateRequired()) {


### PR DESCRIPTION
AudioEngineDevice calls `-[AVAudioEngine connect:to:format:]` in five places with no exception handling. When the engine rewires while the audio session is in a transient state (mic unmute, enabling the camera mid-call, route changes), the hardware format can come back invalid (0 Hz) and `connect:` throws:

```
com.apple.coreaudio.avfaudio: required condition is false: IsFormatSampleRateAndChannelCountValid(format)
```

The exception is raised on a webrtc-owned thread, so apps can't catch it and it takes the whole process down. It's currently the #1 crash in our production app (stream-video-react-native-sdk, StreamWebRTC 137.0.75, iOS only), around 500 crashes a month, and the unguarded calls are still present on main and the 148 line.

This is a known failure mode of the AVAudioEngine device (livekit/client-sdk-swift#577) and was fixed upstream in webrtc-sdk/webrtc#228. This ports the connect guards from there, in the same style as the detach/start guards this file already has: a failed connect logs and returns kAudioEngineDeviceFormatError (through the existing rollback path where there is one) instead of aborting.

I can't build the framework locally so this is compile-untested; happy to adjust if you'd like it structured differently. Would be great to see this in a StreamWebRTC release on the 145 line and forward-merged to m148.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio engine stability by safely handling failures during audio input and output setup.
  * Added clearer error reporting when audio device connections cannot be established.
  * Ensured failed audio configurations exit cleanly with an appropriate device-format error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->