### PR TITLE
[Enhancement] iOS Audio engine input / output availability 

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -122,6 +122,11 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool output_enabled = false;
     bool output_running = false;
 
+    // Default true: the engine may activate on init.
+    // Set false to gate start/stop (e.g. CallKit).
+    bool output_available = true;
+    bool input_available = true;
+
     // Output will be enabled when input is enabled
     bool input_follow_mode = true;
     bool input_enabled_persistent_mode = false;
@@ -151,6 +156,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool operator==(const EngineState& rhs) const {
       return input_enabled == rhs.input_enabled && input_running == rhs.input_running &&
              output_enabled == rhs.output_enabled && output_running == rhs.output_running &&
+             input_available == rhs.input_available && output_available == rhs.output_available &&
              input_follow_mode == rhs.input_follow_mode &&
              input_enabled_persistent_mode == rhs.input_enabled_persistent_mode &&
              input_muted == rhs.input_muted && is_interrupted == rhs.is_interrupted &&
@@ -172,32 +178,31 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
     bool IsOutputInputLinked() const { return input_follow_mode && voice_processing_enabled; }
 
     bool IsOutputEnabled() const {
-      return IsOutputInputLinked() ? (IsInputEnabled() || output_enabled) : output_enabled;
+      bool result = IsOutputInputLinked() ? (IsInputEnabled() || output_enabled) : output_enabled;
+      return output_available && result;
     }
 
     bool IsOutputRunning() const {
-      return IsOutputInputLinked() ? (IsInputRunning() || output_running) : output_running;
+      bool result = IsOutputInputLinked() ? (IsInputRunning() || output_running) : output_running;
+      return output_available && result;
     }
 
     bool IsInputEnabled() const {
-      return !(mute_mode == MuteMode::RestartEngine && input_muted) &&
-             (input_enabled || input_enabled_persistent_mode);
+      bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) &&
+                    (input_enabled || input_enabled_persistent_mode);
+      return input_available && result;
     }
 
     bool IsInputRunning() const {
-      return !(mute_mode == MuteMode::RestartEngine && input_muted) && input_running;
+      bool result = !(mute_mode == MuteMode::RestartEngine && input_muted) && input_running;
+      return input_available && result;
     }
 
     bool IsAnyEnabled() const { return IsInputEnabled() || IsOutputEnabled(); }
     bool IsAnyRunning() const { return IsInputRunning() || IsOutputRunning(); }
 
-    bool IsAllEnabled() const {
-      return IsOutputInputLinked() ? IsInputEnabled() : IsInputEnabled() && output_enabled;
-    }
-
-    bool IsAllRunning() const {
-      return IsOutputInputLinked() ? input_running : input_running && output_running;
-    }
+    bool IsAllEnabled() const { return IsInputEnabled() && IsOutputEnabled(); }
+    bool IsAllRunning() const { return IsInputRunning() && IsOutputRunning(); }
 
     bool IsOutputDefaultDevice() const {
 #if TARGET_OS_OSX
@@ -317,6 +322,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   int32_t SetEngineState(EngineState enable);
   int32_t GetEngineState(EngineState* enabled);
+
+  int32_t SetEngineAvailability(bool input_available, bool output_available);
+  int32_t EngineAvailability(bool* input_available, bool* output_available);
 
   int32_t SetObserver(AudioDeviceObserver* observer) override;
   bool IsAudioEngineDevice() const override { return true; }
@@ -440,6 +448,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   bool IsMicrophonePermissionGranted();
   void ResetEngineState();
   int32_t ModifyEngineState(std::function<EngineState(EngineState)> state_transform);
+
   int32_t ApplyDeviceEngineState(EngineStateUpdate& state);
   int32_t ApplyManualEngineState(EngineStateUpdate& state);
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -1260,6 +1260,33 @@ int32_t AudioEngineDevice::SetVoiceProcessingAGCEnabled(bool enable) {
   return result;
 }
 
+int32_t AudioEngineDevice::SetEngineAvailability(bool input_available, bool output_available) {
+  RTC_DCHECK_RUN_ON(thread_);
+  LOGI() << "SetEngineAvailability: " << input_available << " " << output_available;
+
+  int32_t result =
+      ModifyEngineState([input_available, output_available](EngineState state) -> EngineState {
+        state.input_available = input_available;
+        state.output_available = output_available;
+        return state;
+      });
+
+  return result;
+}
+
+int32_t AudioEngineDevice::EngineAvailability(bool* input_available, bool* output_available) {
+  RTC_DCHECK_RUN_ON(thread_);
+
+  if (input_available == nullptr || output_available == nullptr) {
+    return -1;
+  }
+
+  *input_available = engine_state_.input_available;
+  *output_available = engine_state_.output_available;
+
+  return 0;
+}
+
 int32_t AudioEngineDevice::ManualRenderingMode(bool* enabled) {
   LOGI() << "ManualRenderingMode";
   RTC_DCHECK_RUN_ON(thread_);
@@ -2816,6 +2843,8 @@ void AudioEngineDevice::DebugEngineState(const std::string& prefix,
          << ", IsAnyRunning: " << state.IsAnyRunning()
          << ", IsAllEnabled: " << state.IsAllEnabled()
          << ", IsAllRunning: " << state.IsAllRunning()
+         << ", InputAvailable: " << state.input_available
+         << ", OutputAvailable: " << state.output_available
          << ", AdvancedDucking: " << state.advanced_ducking
          << ", DuckingLevel: " << state.ducking_level
          << ", MuteMode: " << static_cast<int>(state.mute_mode)

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.h
@@ -49,12 +49,17 @@ typedef struct {
   RTC_OBJC_TYPE(RTCAudioEngineMuteMode) muteMode;
 } RTC_OBJC_TYPE(RTCAudioEngineState);
 
-typedef struct { 
-  bool voiceProcessingEnabled; 
-  bool voiceProcessingBypassed; 
-  bool voiceProcessingAGCEnabled; 
-  bool stereoPlayoutEnabled; 
+typedef struct {
+  bool voiceProcessingEnabled;
+  bool voiceProcessingBypassed;
+  bool voiceProcessingAGCEnabled;
+  bool stereoPlayoutEnabled;
 } RTC_OBJC_TYPE(RTCAudioProcessingState);
+
+typedef struct {
+  bool isInputAvailable;
+  bool isOutputAvailable;
+} RTC_OBJC_TYPE(RTCAudioEngineAvailability);
 
 RTC_EXTERN NSString *const RTC_CONSTANT_TYPE(RTCAudioEngineInputMixerNodeKey);
 
@@ -153,6 +158,8 @@ RTC_OBJC_EXPORT
 
 - (NSInteger)initAndStartRecording;
 
+- (NSInteger)setEngineAvailability:(RTC_OBJC_TYPE(RTCAudioEngineAvailability))availability;
+
 // For testing purposes
 @property(nonatomic, readonly) BOOL isPlayoutInitialized;
 @property(nonatomic, readonly) BOOL isRecordingInitialized;
@@ -204,6 +211,8 @@ RTC_OBJC_EXPORT
 // this is true.
 @property(nonatomic, assign) BOOL prefersStereoPlayout;
 - (void)refreshStereoPlayoutState;
+
+@property(nonatomic, readonly) RTC_OBJC_TYPE(RTCAudioEngineAvailability) engineAvailability;
 
 @end
 

--- a/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
+++ b/sdk/objc/api/peerconnection/RTCAudioDeviceModule.mm
@@ -566,6 +566,44 @@ class AudioDeviceObserver : public webrtc::AudioDeviceObserver {
 
 #pragma mark - Unique to AudioEngineDevice
 
+- (NSInteger)setEngineAvailability:(RTC_OBJC_TYPE(RTCAudioEngineAvailability))availability {
+#if !defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
+  return -1;
+#else
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return -1;
+  }
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return -1;
+
+  return _workerThread->BlockingCall([module, availability] {
+    return module->SetEngineAvailability(availability.isInputAvailable,
+                                         availability.isOutputAvailable);
+  });
+#endif
+}
+
+- (RTC_OBJC_TYPE(RTCAudioEngineAvailability))engineAvailability {
+#if !defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
+  return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
+#else
+  if (![self isNativeModuleReady] || ![self isWorkerThreadReady] || ![self isAudioEngineModule]) {
+    return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
+  }
+  webrtc::AudioEngineDevice *module = static_cast<webrtc::AudioEngineDevice *>(_native.get());
+  if (module == nullptr) return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
+
+  return _workerThread->BlockingCall([module] {
+    bool input_available = false;
+    bool output_available = false;
+    int32_t result = module->EngineAvailability(&input_available, &output_available);
+    if (result != 0) return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(NO, NO);
+
+    return RTC_OBJC_TYPE(RTCAudioEngineAvailability)(input_available, output_available);
+  });
+#endif
+}
+
 - (BOOL)isRecordingAlwaysPreparedMode {
 #if !defined(WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE)
   return NO;


### PR DESCRIPTION
# WebRTC Changelog 145.11.0 — Audio Engine Availability (develop → main)

Release `145.11.0` is a **patch release** on top of `145.10.0`. It contains **no WebRTC baseline bump** — the upstream `webrtc.googlesource.com/src` revision is unchanged from the previous release. The only change is a Stream fork addition to the iOS/macOS `AudioEngineDevice`, giving hosts an explicit way to gate when the audio engine is allowed to start and stop.

**Compare:** https://github.com/GetStream/webrtc/compare/main...develop
**Range:** `ee2a4bef1711` … `813e3d764850` (1 commit, first-parent)

---

## Summary

`AudioEngineDevice` previously started the input and output engines purely as a function of its own enabled/running state. That works when WebRTC owns the audio lifecycle, but breaks in host-driven flows — most notably **CallKit**, where the system decides when `AVAudioSession` becomes active and starting `AVAudioEngine` too early (or too late) results in no audio, a dropped route, or a hard engine failure.

This release adds an **availability gate**: two independent flags (`inputAvailable` / `outputAvailable`) that act as a veto on top of all existing engine-state logic. Both default to `true`, so **existing behavior is unchanged unless an integrator opts in** by setting availability to `false`. Once set, the engine will not enable or run the corresponding direction regardless of what the rest of the state machine wants — letting the host hold the engine back until the platform says it is safe to start, then release it.

The change is ported from the upstream `webrtc-sdk/webrtc` fork (PR #196) and adapted for Stream, with the ObjC entry points guarded to match the rest of the audio-engine surface.

---

## Categories

Counts as reported by `scripts/generate_changelog.py` for `origin/main..origin/develop`:

| Category | Count |
| --- | --- |
| Upstream WebRTC merge | 0 |
| Features | 0 |
| Fixes | 0 |
| Platform / build | 0 |
| Tests / internal | 0 |
| Other changes | 0 |
| **Breaking change review (public headers / packaged API)** | **1** |
| **Total commits in range** | **1** |

The single commit is not auto-classified into a feature/fix bucket; it is flagged for **breaking change review** because it touches packaged public headers. See *Notes for Reviewers* — the API change is purely additive.

---

## Stream Integration Highlights

* **New engine availability gate (iOS / macOS).** `AudioEngineDevice::EngineState` gains `input_available` and `output_available` (both defaulting to `true`). Every enabled/running query — `IsInputEnabled`, `IsInputRunning`, `IsOutputEnabled`, `IsOutputRunning` — now ANDs its result with the matching availability flag, so a single flag suppresses start/stop for that direction across the whole state machine rather than at individual call sites.
* **Native control surface.** `AudioEngineDevice::SetEngineAvailability(bool input, bool output)` and `AudioEngineDevice::EngineAvailability(bool*, bool*)` are added, both asserting they run on the device thread. Setting availability goes through the existing `ModifyEngineState` transform, so a change is applied and reconciled the same way as any other engine-state transition — no separate code path.
* **Public ObjC API (additive).** `RTCAudioDeviceModule` exposes:
  * `- (NSInteger)setEngineAvailability:(RTCAudioEngineAvailability)availability;`
  * `@property(nonatomic, readonly) RTCAudioEngineAvailability engineAvailability;`

  backed by a new lightweight struct `RTCAudioEngineAvailability { bool isInputAvailable; bool isOutputAvailable; }`. Both hop to the worker thread via `BlockingCall`, and both are guarded on `WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE`, native-module readiness, worker-thread readiness, and `isAudioEngineModule` — matching the guard pattern already used by the other audio-engine-only members. Guard failures return `-1` (setter) or `(NO, NO)` (getter) instead of touching a null module.
* **Simplified aggregate state predicates.** `IsAllEnabled()` / `IsAllRunning()` are rewritten as plain `IsInputEnabled() && IsOutputEnabled()` and `IsInputRunning() && IsOutputRunning()`, replacing the previous branch on `IsOutputInputLinked()`. This removes duplicated linkage logic and ensures the new availability gate is honored by the aggregate predicates too.
* **Debug logging.** `DebugEngineState` now prints `InputAvailable` / `OutputAvailable`, so availability is visible in engine-state dumps when diagnosing "engine didn't start" reports.
* **Header tidy-up.** Trailing whitespace removed from the `RTCAudioProcessingState` struct declaration. No functional effect.

**Primary use case:** with CallKit, set availability to `false` while the call is being set up, then flip it to `true` from `provider:didActivateAudioSession:` so the engine starts only once the system session is active — and back to `false` on deactivation.

---

## Fixes

None in this release.

## Platform / build

No build, toolchain, GN, or dependency changes. `DEPS` and the upstream baseline are untouched, so this release rebuilds against the same WebRTC revision as `145.10.0`.

---

## Notes for Reviewers

* **Public API surface changed — additive only.** `sdk/objc/api/peerconnection/RTCAudioDeviceModule.h` gains one struct, one method, and one readonly property. Nothing was renamed, removed, or re-typed, so existing consumers compile and behave unchanged. `RTCAudioEngineAvailability` is new and needs to be visible in the packaged framework headers — worth confirming it is exported alongside the other `RTC_OBJC_TYPE` audio-engine structs when the xcframework is built.
* **Default is backwards-compatible.** `input_available` and `output_available` initialize to `true` in `EngineState`, and nothing in this change writes them except the new setter. A build that never calls `setEngineAvailability:` is behaviorally identical to `145.10.0`.
* **`IsAllEnabled` is equivalent; `IsAllRunning` is subtly stricter.** For `IsAllEnabled`, the new expression reduces to the old one in both the linked and unlinked cases. For `IsAllRunning`, the old form compared the raw `input_running` field, whereas `IsInputRunning()` also applies the `MuteMode::RestartEngine && input_muted` guard. Net effect: a muted-via-engine-restart device is no longer reported as "all running". This looks correct and intended, but it is the one place where behavior changes without anyone opting in — worth a focused check against mute/unmute flows using `MuteMode::RestartEngine`.
* **Availability is a veto, not a request.** Setting `outputAvailable = false` suppresses output even when output is enabled and linked to input. Because `IsOutputInputLinked()` makes output follow input, gating **input** alone will also stop output in voice-processing mode. Integrators generally want to set both flags together.
* **Getter returns `(NO, NO)` on guard failure.** `engineAvailability` cannot distinguish "input and output are both unavailable" from "the audio engine module isn't ready / this isn't an engine module". Callers should not treat a `(NO, NO)` read as authoritative before the ADM is initialized.
* **Threading.** Native methods are annotated `RTC_DCHECK_RUN_ON(thread_)` and reached only via `_workerThread->BlockingCall`. `setEngineAvailability:` and `engineAvailability` are therefore synchronous and blocking — do not call them from an audio-render or other latency-sensitive callback.
* **Scope is Apple platforms only.** Four files changed (+102 / −17): `modules/audio_device/audio_engine_device.{h,mm}` and `sdk/objc/api/peerconnection/RTCAudioDeviceModule.{h,mm}`. No Android, Java/JNI, frame-cryptor, `pc/`, or `api/` changes — Android artifacts for this release carry no source changes.
* **Provenance.** Ported from `webrtc-sdk/webrtc` PR #196, co-authored by Hiroshi Horie, with Stream-side review fixes (the guard hardening on `setEngineAvailability:` / `engineAvailability`).
* **No automated coverage added.** There are no unit tests for the availability gate; validation should be manual on a device — a normal call to confirm the default path is unchanged, and a CallKit-driven call to confirm the gate defers engine start until the system session activates.

---

## Publish

* **Version:** `145.11.0`
* **Alpha:** off (stable release — pre-releases use the workflow's `alpha` flag rather than a version suffix)
* **Merge:** `develop` → `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controls to set and query audio engine input and output availability.
  - Added Objective-C APIs for managing and reading audio engine availability.
  - Audio engine state now distinguishes input and output availability.
- **Behavior Changes**
  - Disabled or unavailable input/output paths are no longer reported as enabled or running.
  - Availability is included in audio engine state diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->