### PR TITLE
[Fix] Make late AVAudioSinkNode callbacks safe during teardown

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -17,7 +17,6 @@
 #ifndef SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 #define SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 
-#include <atomic>
 #include <memory>
 #include <string>
 
@@ -26,6 +25,9 @@
 #include "api/task_queue/pending_task_safety_flag.h"
 #include "modules/audio_device/audio_device_generic.h"
 #include "rtc_base/buffer.h"
+// Use the repository's annotated mutex to make render/teardown ordering
+// visible to Clang's thread-safety analysis.
+#include "rtc_base/synchronization/mutex.h"
 #include "rtc_base/thread.h"
 #include "rtc_base/thread_annotations.h"
 #include "sdk/objc/base/RTCMacros.h"
@@ -98,7 +100,52 @@ enum AudioEngineErrorCode {
   kAudioEngineAGCError = -8001
 };
 
+// Avoid pulling the full buffer definition into every audio-engine consumer.
+class AudioDeviceBuffer;
 class FineAudioBuffer;
+
+/// Keeps sink-callback resources alive without extending device ownership.
+///
+/// AVAudioEngine may invoke a copied sink block after graph teardown begins.
+/// This context lets teardown close that callback gate before releasing the
+/// conversion resources that a late invocation could otherwise access.
+class AudioEngineInputRenderContext {
+ public:
+  /// Builds the callback-local converter while leaving buffer ownership with
+  /// AudioEngineDevice.
+  AudioEngineInputRenderContext(AVAudioFormat* engine_format,
+                                AVAudioFormat* rtc_format,
+                                std::shared_ptr<AudioDeviceBuffer> audio_device_buffer,
+                                double mach_tick_units_to_nanoseconds);
+  /// Provides safe fallback cleanup if a block releases its last reference.
+  ~AudioEngineInputRenderContext();
+
+  /// Closes the callback gate and drains any render that already holds it.
+  void Invalidate();
+  /// Converts and delivers input only while teardown has not invalidated it.
+  OSStatus Render(const AudioTimeStamp* timestamp,
+                  AVAudioFrameCount frame_count,
+                  const AudioBufferList* input_data);
+
+ private:
+  // Serializes conversion with teardown so converter state cannot be disposed
+  // while AVAudioEngine is still using it.
+  Mutex mutex_;
+  // Turns callbacks copied by AVAudioEngine into no-ops after graph teardown.
+  bool is_valid_ RTC_GUARDED_BY(mutex_) = true;
+  // Prevents the callback block from becoming the final owner of the
+  // sequence-affine AudioDeviceBuffer.
+  const std::weak_ptr<AudioDeviceBuffer> audio_device_buffer_;
+  // Owns the callback's raw buffer link only until invalidation drains render.
+  std::unique_ptr<FineAudioBuffer> fine_audio_buffer_ RTC_GUARDED_BY(mutex_);
+  // Keeps conversion state with the callback lifetime instead of the device
+  // object whose graph may already be releasing.
+  AudioConverterRef converter_ref_ RTC_GUARDED_BY(mutex_) = nullptr;
+  // Retains converted sample storage until render completes or is invalidated.
+  AVAudioPCMBuffer* converter_buffer_ RTC_GUARDED_BY(mutex_) = nil;
+  // Preserves the engine's host-time conversion without capturing the device.
+  const double mach_tick_units_to_nanoseconds_;
+};
 
 extern NSString* const kAudioEngineInputMixerNodeKey;
 
@@ -503,6 +550,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   void NotifyProcessingStateObserver(EngineStateUpdate state);
 
+  // Ends callback access before any path detaches or releases the input graph.
+  void InvalidateInputRenderContext();
+
   // Thread that this object is created on.
   webrtc::Thread* thread_;
   std::unique_ptr<webrtc::Thread> render_thread_;
@@ -510,7 +560,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   AVAudioPCMBuffer* read_buffer_;
 
   const std::unique_ptr<TaskQueueFactory> task_queue_factory_;
-  std::unique_ptr<AudioDeviceBuffer> audio_device_buffer_;
+  // Remains the long-lived owner while render contexts take only weak access.
+  std::shared_ptr<AudioDeviceBuffer> audio_device_buffer_;
   std::unique_ptr<FineAudioBuffer> fine_audio_buffer_;
 
   AudioParameters playout_parameters_;
@@ -548,9 +599,9 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   AVAudioSinkNode* sink_node_ RTC_GUARDED_BY(thread_);
   AVAudioMixerNode* input_mixer_node_ RTC_GUARDED_BY(thread_);
 
-  // Float32 -> Int16 converter.
-  AudioConverterRef converter_ref_;
-  AVAudioPCMBuffer* converter_buffer_;
+  // Lets device teardown invalidate the context even when the sink block keeps
+  // its own copy alive for a late callback.
+  std::shared_ptr<AudioEngineInputRenderContext> input_render_context_;
 
   void* configuration_observer_ RTC_GUARDED_BY(thread_);
 };

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -89,6 +89,13 @@ AudioEngineInputRenderContext::AudioEngineInputRenderContext(
   // lifetime as the converter itself.
   converter_buffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:rtc_format
                                                     frameCapacity:kMaximumFramesPerBuffer];
+  // Reject partial native allocation in release builds because Render cannot
+  // safely recover from missing conversion resources on the audio thread.
+  if (err != noErr || converter_ref_ == nullptr || converter_buffer_ == nil) {
+    // Close the callback gate while leaving Invalidate to release any resource
+    // that was created before the other allocation failed.
+    is_valid_ = false;
+  }
 }
 
 AudioEngineInputRenderContext::~AudioEngineInputRenderContext() {
@@ -101,11 +108,6 @@ void AudioEngineInputRenderContext::Invalidate() {
   // Taking the render lock drains a callback that already entered conversion
   // and prevents any later callback from observing partially released state.
   MutexLock lock(&mutex_);
-  // Repeated rollback and release paths can safely share this cleanup method.
-  if (!is_valid_) {
-    return;
-  }
-
   // Close the callback gate before dropping any resource it may access.
   is_valid_ = false;
   // Remove FineAudioBuffer's raw AudioDeviceBuffer link while the device still
@@ -127,21 +129,28 @@ void AudioEngineInputRenderContext::Invalidate() {
 OSStatus AudioEngineInputRenderContext::Render(const AudioTimeStamp* timestamp,
                                                AVAudioFrameCount frame_count,
                                                const AudioBufferList* input_data) {
-  // Hold the teardown gate across conversion and delivery because both use
-  // resources that Invalidate releases together.
-  MutexLock lock(&mutex_);
+  // Never make AVAudioEngine's real-time callback wait for another render or
+  // teardown user of the shared conversion resources.
+  if (!mutex_.TryLock()) {
+    return noErr;
+  }
   // AVAudioEngine may invoke its copied block after detach; that callback must
   // succeed as a no-op without touching released input pointers.
   if (!is_valid_) {
+    // Release the non-blocking gate before returning from the ignored callback.
+    mutex_.Unlock();
     return noErr;
   }
 
   // Promote weak access only for this render so the callback never owns the
-  // buffer beyond active work.
-  const auto audio_device_buffer = audio_device_buffer_.lock();
+  // buffer beyond active work, and keep it mutable so it can be dropped before
+  // teardown reacquires the gate.
+  auto audio_device_buffer = audio_device_buffer_.lock();
   // Device destruction can win the race before callback entry; no delivery is
   // possible once the owner is gone.
   if (audio_device_buffer == nullptr) {
+    // A failed weak promotion owns no device state, so release the gate now.
+    mutex_.Unlock();
     return noErr;
   }
 
@@ -185,6 +194,11 @@ OSStatus AudioEngineInputRenderContext::Render(const AudioTimeStamp* timestamp,
       webrtc::ArrayView<const int16_t>(rtc_buffer, frame_count), kFixedRecordDelayEstimate,
       capture_time_ns);
 
+  // Drop render-scoped ownership before teardown can release the device's
+  // strong owner, preserving AudioDeviceBuffer destruction on its sequence.
+  audio_device_buffer.reset();
+  // Release conversion resources to teardown only after render is fully done.
+  mutex_.Unlock();
   // A completed or intentionally ignored sink callback is successful to
   // AVAudioEngine, so teardown does not provoke a second error path.
   return noErr;
@@ -2918,6 +2932,9 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
 }
 
 void AudioEngineDevice::InvalidateInputRenderContext() {
+  // Context ownership is confined to the device-control thread so graph and
+  // callback teardown keep the same sequence ordering.
+  RTC_DCHECK_RUN_ON(thread_);
   // A missing context means input setup never completed or teardown already
   // consumed the device's reference.
   if (input_render_context_ != nullptr) {

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -64,13 +64,141 @@ const useconds_t kVoiceProcessingRetryDelayMs = 100;
 const size_t kMaximumFramesPerBuffer = 3072;
 const size_t kAudioSampleSize = 2;  // Signed 16-bit integer
 
+AudioEngineInputRenderContext::AudioEngineInputRenderContext(
+    AVAudioFormat* engine_format,
+    AVAudioFormat* rtc_format,
+    std::shared_ptr<AudioDeviceBuffer> audio_device_buffer,
+    double mach_tick_units_to_nanoseconds)
+    // Observe the device-owned buffer without extending its destruction
+    // sequence to the AVAudioEngine callback thread.
+    : audio_device_buffer_(audio_device_buffer),
+      // FineAudioBuffer caches a raw buffer pointer, so invalidation must
+      // destroy it before the device owner can disappear.
+      fine_audio_buffer_(
+          std::make_unique<FineAudioBuffer>(audio_device_buffer.get())),
+      // Copy the scalar timing ratio instead of capturing AudioEngineDevice.
+      mach_tick_units_to_nanoseconds_(mach_tick_units_to_nanoseconds) {
+  // Move the converter beside the sink callback so its lifetime follows every
+  // copied block invocation rather than the releasing engine object.
+  OSStatus err = AudioConverterNew(engine_format.streamDescription,
+                                   rtc_format.streamDescription, &converter_ref_);
+  // Preserve the original construction invariant: rendering requires a valid
+  // converter and cannot recover inside the real-time callback.
+  RTC_DCHECK(err == noErr);
+  // Keep the converter's destination memory alive for the same guarded
+  // lifetime as the converter itself.
+  converter_buffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:rtc_format
+                                                    frameCapacity:kMaximumFramesPerBuffer];
+}
+
+AudioEngineInputRenderContext::~AudioEngineInputRenderContext() {
+  // Normal teardown invalidates on the device thread; this fallback prevents a
+  // missed path from leaking callback-local conversion resources.
+  Invalidate();
+}
+
+void AudioEngineInputRenderContext::Invalidate() {
+  // Taking the render lock drains a callback that already entered conversion
+  // and prevents any later callback from observing partially released state.
+  MutexLock lock(&mutex_);
+  // Repeated rollback and release paths can safely share this cleanup method.
+  if (!is_valid_) {
+    return;
+  }
+
+  // Close the callback gate before dropping any resource it may access.
+  is_valid_ = false;
+  // Remove FineAudioBuffer's raw AudioDeviceBuffer link while the device still
+  // owns the underlying sequence-affine object.
+  fine_audio_buffer_.reset();
+  // Dispose the converter on the device-control sequence after in-flight
+  // conversion has completed under the same lock.
+  if (converter_ref_ != nullptr) {
+    OSStatus err = AudioConverterDispose(converter_ref_);
+    // Match creation's invariant while ensuring repeated invalidation cannot
+    // dispose the converter twice.
+    RTC_DCHECK(err == noErr);
+    converter_ref_ = nullptr;
+  }
+  // Release the Objective-C sample storage with the converter it backs.
+  converter_buffer_ = nil;
+}
+
+OSStatus AudioEngineInputRenderContext::Render(const AudioTimeStamp* timestamp,
+                                               AVAudioFrameCount frame_count,
+                                               const AudioBufferList* input_data) {
+  // Hold the teardown gate across conversion and delivery because both use
+  // resources that Invalidate releases together.
+  MutexLock lock(&mutex_);
+  // AVAudioEngine may invoke its copied block after detach; that callback must
+  // succeed as a no-op without touching released input pointers.
+  if (!is_valid_) {
+    return noErr;
+  }
+
+  // Promote weak access only for this render so the callback never owns the
+  // buffer beyond active work.
+  const auto audio_device_buffer = audio_device_buffer_.lock();
+  // Device destruction can win the race before callback entry; no delivery is
+  // possible once the owner is gone.
+  if (audio_device_buffer == nullptr) {
+    return noErr;
+  }
+
+  // The configured mono sink and converter must agree on one input buffer.
+  RTC_DCHECK(input_data->mNumberBuffers == 1);
+
+  // AVAudioPCMBuffer owns the writable list; AudioConverter's C API requires
+  // the non-const view used only during this guarded conversion.
+  AudioBufferList* converter_buffer_abl =
+      const_cast<AudioBufferList*>(converter_buffer_.audioBufferList);
+  // Reject an engine format change that would violate the prepared converter.
+  RTC_DCHECK(converter_buffer_abl->mNumberBuffers == input_data->mNumberBuffers);
+
+  // Fails for conversions where there is a variation between the input and output data
+  // buffer sizes.
+  converter_buffer_abl->mBuffers[0].mDataByteSize = input_data->mBuffers[0].mDataByteSize;
+
+  // Keep the prepared output view aligned with the engine input before the C
+  // converter reads either list.
+  RTC_DCHECK(converter_buffer_abl->mBuffers[0].mDataByteSize ==
+             input_data->mBuffers[0].mDataByteSize);
+
+  // Convert while teardown is excluded so AudioConverterDispose cannot race
+  // this call.
+  OSStatus err = AudioConverterConvertComplexBuffer(converter_ref_, frame_count, input_data,
+                                                    converter_buffer_abl);
+  // The render path cannot substitute valid recorded data after conversion
+  // failure, matching the previous callback behavior.
+  RTC_DCHECK(err == noErr);
+
+  // Reuse the converter's Int16 storage without copying on the audio thread.
+  const int16_t* rtc_buffer =
+      static_cast<int16_t*>(converter_buffer_abl->mBuffers[0].mData);
+  // Preserve AVAudioEngine's host timestamp after removing the device capture.
+  const int64_t capture_time_ns =
+      timestamp->mHostTime * mach_tick_units_to_nanoseconds_;
+
+  // Deliver while the temporary strong buffer reference and teardown lock are
+  // both held, then release that reference back on this callback invocation.
+  fine_audio_buffer_->DeliverRecordedData(
+      webrtc::ArrayView<const int16_t>(rtc_buffer, frame_count), kFixedRecordDelayEstimate,
+      capture_time_ns);
+
+  // A completed or intentionally ignored sink callback is successful to
+  // AVAudioEngine, so teardown does not provoke a second error path.
+  return noErr;
+}
+
 AudioEngineDevice::AudioEngineDevice(bool voice_processing_bypassed)
     : task_queue_factory_(CreateDefaultTaskQueueFactory()), initialized_(false) {
   LOGI() << "voice_processing_bypassed " << voice_processing_bypassed;
 
   thread_ = webrtc::Thread::Current();
-  audio_device_buffer_.reset(
-      new webrtc::AudioDeviceBuffer(webrtc::CreateEnvironment(task_queue_factory_.get())));
+  // Keep the device as the long-lived owner while callback contexts obtain
+  // only weak, render-scoped access.
+  audio_device_buffer_ = std::make_shared<webrtc::AudioDeviceBuffer>(
+      webrtc::CreateEnvironment(task_queue_factory_.get()));
 
 #if defined(WEBRTC_IOS)
   audio_session_observer_ =
@@ -1976,6 +2104,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
         return result;
       }
     }
+    // Drain callbacks before graph release can free their converter resources.
+    InvalidateInputRenderContext();
     // Drop the old graph only after all owners have released it.
     engine_device_ = nil;
     // Report that the engine is fully released and safe to replace.
@@ -2425,48 +2555,23 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
     RTC_DCHECK(audio_device_buffer_ != nullptr);
     fine_audio_buffer_.reset(new FineAudioBuffer(audio_device_buffer_.get()));
 
-    // Prepare Float32 -> Int16 converter.
-    if (converter_ref_ == nullptr) {
-      OSStatus err = AudioConverterNew(engine_input_format.streamDescription,
-                                       rtc_input_format.streamDescription, &converter_ref_);
-      RTC_DCHECK(err == noErr);
-    }
-
-    // Prepare buffer for Int16 converter.
-    if (converter_buffer_ == nil) {
-      converter_buffer_ = [[AVAudioPCMBuffer alloc] initWithPCMFormat:rtc_input_format
-                                                        frameCapacity:kMaximumFramesPerBuffer];
-    }
+    // Give copied sink blocks their own guarded converter lifetime without
+    // capturing AudioEngineDevice.
+    input_render_context_ = std::make_shared<AudioEngineInputRenderContext>(
+        engine_input_format, rtc_input_format, audio_device_buffer_,
+        machTickUnitsToNanoseconds_);
+    // Tear down partially configured input through the same callback gate.
+    rollback_actions.push_back([this] { InvalidateInputRenderContext(); });
+    // Capture the context by value because AVAudioEngine owns a copied block
+    // that can outlive the device's reference during graph release.
+    const auto input_render_context = input_render_context_;
 
     // Convert to Int16 buffers within the sink block.
     AVAudioSinkNodeReceiverBlock sink_block =
         ^OSStatus(const AudioTimeStamp* timestamp, AVAudioFrameCount frameCount,
                   const AudioBufferList* inputData) {
-          RTC_DCHECK(inputData->mNumberBuffers == 1);
-
-          AudioBufferList* converter_buffer_abl =
-              const_cast<AudioBufferList*>(converter_buffer_.audioBufferList);
-          RTC_DCHECK(converter_buffer_abl->mNumberBuffers == inputData->mNumberBuffers);
-
-          // Fails for conversions where there is a variation between the input and output data
-          // buffer sizes.
-          converter_buffer_abl->mBuffers[0].mDataByteSize = inputData->mBuffers[0].mDataByteSize;
-
-          RTC_DCHECK(converter_buffer_abl->mBuffers[0].mDataByteSize ==
-                     inputData->mBuffers[0].mDataByteSize);
-
-          OSStatus err = AudioConverterConvertComplexBuffer(converter_ref_, frameCount, inputData,
-                                                            converter_buffer_abl);
-          RTC_DCHECK(err == noErr);
-
-          const int16_t* rtc_buffer = (int16_t*)converter_buffer_abl->mBuffers[0].mData;  // Float32
-          const int64_t capture_time_ns = timestamp->mHostTime * machTickUnitsToNanoseconds_;
-
-          fine_audio_buffer_->DeliverRecordedData(
-              webrtc::ArrayView<const int16_t>(rtc_buffer, frameCount), kFixedRecordDelayEstimate,
-              capture_time_ns);
-
-          return noErr;
+          // Route every invocation through the guarded lifetime boundary.
+          return input_render_context->Render(timestamp, frameCount, inputData);
         };
 
     NSMutableArray<AVAudioConnectionPoint*>* input_mixer_connections = [NSMutableArray array];
@@ -2521,6 +2626,8 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
              !state.IsEngineRecreateRequired()) {
     LOGI() << "Disabling input for AVAudioEngine...";
     RTC_DCHECK(!engine_device_.running);
+    // Close and drain the callback before detaching either input node.
+    InvalidateInputRenderContext();
 
     // If disabling input, always unmute the voice-processing input mute.
     if (inputNode().voiceProcessingEnabled && inputNode().voiceProcessingInputMuted) {
@@ -2556,15 +2663,6 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
       }
     }
 
-    // Dispose Float32 -> Int16 converter.
-    if (converter_ref_ != nullptr) {
-      OSStatus err = AudioConverterDispose(converter_ref_);
-      RTC_DCHECK(err == noErr);
-      converter_ref_ = nullptr;
-    }
-
-    // Release buffer for Int16 converter.
-    converter_buffer_ = nil;
   }
 
   // --------------------------------------------------------------------------------------------
@@ -2817,6 +2915,19 @@ int32_t AudioEngineDevice::ApplyDeviceEngineState(EngineStateUpdate& state) {
   }
 
   return 0;
+}
+
+void AudioEngineDevice::InvalidateInputRenderContext() {
+  // A missing context means input setup never completed or teardown already
+  // consumed the device's reference.
+  if (input_render_context_ != nullptr) {
+    // Release callback-local raw links and converter state on the owning
+    // device-control sequence after any active render exits.
+    input_render_context_->Invalidate();
+    // The sink block may retain the inert context, but it no longer retains or
+    // accesses sequence-affine production resources.
+    input_render_context_.reset();
+  }
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/sdk/BUILD.gn
+++ b/sdk/BUILD.gn
@@ -1391,6 +1391,10 @@ if (is_ios || is_mac) {
             "../media:codec",
             "../media:rtc_media_base",
             "../media:rtc_media_tests_utils",
+            # The focused Objective-C++ regression constructs the real buffer
+            # and render context, so both direct include owners must be linked.
+            "../modules/audio_device:audio_device_buffer",
+            "../modules/audio_device:audio_device_impl",
             "../modules/video_coding:video_codec_interface",
             "../rtc_base:gunit_helpers",
             "../rtc_base:refcount",

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -10,8 +10,11 @@
 
 #import <XCTest/XCTest.h>
 
+#include <memory>
+#include <thread>
 #include <vector>
 
+#include "api/environment/environment_factory.h"
 #import "api/logging/RTCCallbackLogger.h"
 #import "api/peerconnection/RTCConfiguration.h"
 #import "api/peerconnection/RTCAudioDeviceModule.h"
@@ -21,6 +24,8 @@
 #import "api/peerconnection/RTCRtpTransceiver.h"
 #import "api/peerconnection/RTCSessionDescription.h"
 #import "components/audio/RTCAudioSession+Private.h"
+#include "modules/audio_device/audio_device_buffer.h"
+#include "modules/audio_device/audio_engine_device.h"
 
 @interface RTC_OBJC_TYPE(RTCAudioSession)
 (UnitTesting)
@@ -41,6 +46,63 @@
       return;                                     \
     }                                             \
   } while (false)
+
+- (void)testAudioEngineInputRenderContextIgnoresLateCallbackAfterInvalidation {
+  auto audioDeviceBuffer = std::make_shared<webrtc::AudioDeviceBuffer>(
+      webrtc::CreateEnvironment());
+  audioDeviceBuffer->SetRecordingSampleRate(48000);
+  audioDeviceBuffer->SetRecordingChannels(1);
+
+  AVAudioFormat *engineFormat =
+      [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
+                                      sampleRate:48000
+                                        channels:1
+                                     interleaved:YES];
+  AVAudioFormat *rtcFormat =
+      [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
+                                      sampleRate:48000
+                                        channels:1
+                                     interleaved:YES];
+  auto subject = std::make_shared<webrtc::AudioEngineInputRenderContext>(
+      engineFormat, rtcFormat, audioDeviceBuffer, 1.0);
+
+  subject->Invalidate();
+
+  XCTAssertEqual(noErr, subject->Render(nullptr, 0, nullptr));
+}
+
+- (void)testAudioEngineInputRenderContextDoesNotOwnAudioDeviceBuffer {
+  const std::thread::id ownerThread = std::this_thread::get_id();
+  std::thread::id deleterThread;
+  auto audioDeviceBuffer = std::shared_ptr<webrtc::AudioDeviceBuffer>(
+      new webrtc::AudioDeviceBuffer(webrtc::CreateEnvironment(),
+                                    /*create_detached=*/true),
+      [&deleterThread](webrtc::AudioDeviceBuffer *buffer) {
+        deleterThread = std::this_thread::get_id();
+        delete buffer;
+      });
+
+  AVAudioFormat *engineFormat =
+      [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
+                                      sampleRate:48000
+                                        channels:1
+                                     interleaved:YES];
+  AVAudioFormat *rtcFormat =
+      [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16
+                                      sampleRate:48000
+                                        channels:1
+                                     interleaved:YES];
+  auto subject = std::make_shared<webrtc::AudioEngineInputRenderContext>(
+      engineFormat, rtcFormat, audioDeviceBuffer, 1.0);
+
+  subject->Invalidate();
+  audioDeviceBuffer.reset();
+  std::thread releaseThread(
+      [subject = std::move(subject)]() mutable { subject.reset(); });
+  releaseThread.join();
+
+  XCTAssertEqual(ownerThread, deleterThread);
+}
 
 - (void)testAudioEngineModuleRetainedAfterFactoryDeallocDoesNotKeepAudioSessionDelegate {
   RETURN_IF_SIMULATOR_AUDIO_TEST_DISABLED();


### PR DESCRIPTION
## Summary

- Move input conversion state into a callback-retained context and serialize rendering with invalidation, allowing late `AVAudioSinkNode` callbacks to return safely after teardown begins.
- Keep `AudioDeviceBuffer` ownership on `AudioEngineDevice`, with callbacks acquiring only render-scoped weak access.
- Invalidate the context before engine release, input disable, and setup rollback.
- Add regressions covering late callbacks and owner-sequence destruction.

## Impact

Fixes IOS-1954 (https://linear.app/stream/issue/IOS-1954/crashwebrtc-audiosession-teardown) without public API or migration changes.

## Validation

- `autoninja -C src/out/ios_1922_sim_tests sdk_unittests` with the temporary `stream_enable_rendering_backend = true` GN argument: passed, 76 steps.
- Focused XCTest run on iPhone 17 Pro, iOS 26.5: 2 passed, 0 failed.
  - `testAudioEngineInputRenderContextIgnoresLateCallbackAfterInvalidation`
  - `testAudioEngineInputRenderContextDoesNotOwnAudioDeviceBuffer`
- `autoninja -C src/out/ios_1922_tests modules/audio_device:audio_device_impl`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio input stability during device shutdown, reconfiguration, and delayed callbacks.
  - Prevented stale audio callbacks from accessing released resources.
  - Improved recovery when voice-processing audio engines fail, including retry handling and fallback to speaker-only audio.
  - Reduced the risk of crashes or unexpected behavior when audio components are created or released across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->