### PR TITLE
[Fix] Recover iOS audio after media-services reset

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -360,6 +360,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   void OnInterruptionBegin() override;
   void OnInterruptionEnd(bool should_resume) override;
   void OnValidRouteChange() override;
+  void OnMediaServicesReset() override;
   void OnCanPlayOrRecordChange(bool can_play_or_record) override;
   void OnChangedOutputVolume() override;
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -651,6 +651,16 @@ void AudioEngineDevice::OnValidRouteChange() {
   }));
 }
 
+void AudioEngineDevice::OnMediaServicesReset() {
+  LOGI() << "OnMediaServicesReset";
+  RTC_DCHECK(thread_);
+
+  // A media-services reset invalidates AVAudioEngine and its nodes even though
+  // WebRTC still considers playout and recording started. ReconfigureEngine
+  // rebuilds the graph and restores their prior state.
+  ReconfigureEngine();
+}
+
 void AudioEngineDevice::OnCanPlayOrRecordChange(bool can_play_or_record) {
   LOGI() << "OnCanPlayOrRecordChange";
   RTC_DCHECK(thread_);
@@ -1586,6 +1596,8 @@ void AudioEngineDevice::ReconfigureEngine() {
   thread_->PostTask(SafeTask(safety_, [this] {
     RTC_DCHECK_RUN_ON(thread_);
 
+    // Snapshot on the device thread so stop and availability updates are
+    // ordered before or after the complete recovery transition.
     EngineState current_state = this->engine_state_;
 
     // Re-configure is only for device mode

--- a/sdk/objc/components/audio/RTCAudioSession.mm
+++ b/sdk/objc/components/audio/RTCAudioSession.mm
@@ -41,6 +41,8 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 @interface RTC_OBJC_TYPE (RTCAudioSession)
 () @property(nonatomic, readonly)
     std::vector<__weak id<RTC_OBJC_TYPE(RTCAudioSessionDelegate)> > delegates;
+
+- (void)restoreAudioSessionAfterMediaServicesReset;
 @end
 
 // This class needs to be thread-safe because it is accessed from many threads.
@@ -595,7 +597,7 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 
 - (void)handleMediaServicesWereReset:(NSNotification *)notification {
   RTCLog(@"Media services were reset.");
-  [self updateAudioSessionAfterEvent];
+  [self restoreAudioSessionAfterMediaServicesReset];
   [self notifyMediaServicesWereReset];
 }
 
@@ -676,7 +678,18 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 
 - (NSInteger)decrementActivationCount {
   RTCLog(@"Decrementing activation count.");
-  return _activationCount.fetch_sub(1) - 1;
+  // An unmatched deactivation used to make the count negative. A later valid
+  // activation then still looked inactive during media-services recovery.
+  int activationCount = _activationCount.load();
+  while (activationCount > 0) {
+    if (_activationCount.compare_exchange_weak(activationCount,
+                                               activationCount - 1)) {
+      return activationCount - 1;
+    }
+  }
+
+  RTCLogWarning(@"Ignoring unbalanced audio session deactivation.");
+  return 0;
 }
 
 - (int)webRTCSessionCount {
@@ -812,21 +825,90 @@ ABSL_CONST_INIT thread_local bool mutex_locked = false;
 }
 
 - (void)updateAudioSessionAfterEvent {
-  BOOL shouldActivate = self.activationCount > 0;
-  AVAudioSessionSetActiveOptions options = shouldActivate ?
-      0 :
-      AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation;
+  BOOL shouldActivate = NO;
+  do {
+    shouldActivate = self.activationCount > 0;
+    AVAudioSessionSetActiveOptions options = shouldActivate ?
+        0 :
+        AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation;
+    NSError *error = nil;
+    if ([self.session setActive:shouldActivate
+                    withOptions:options
+                          error:&error]) {
+      self.isActive = shouldActivate;
+      RTCLog(@"Did set session active to %d", shouldActivate);
+    } else {
+      RTCLogError(@"Failed to set session active to %d. Error:%@",
+                  shouldActivate,
+                  error.localizedDescription);
+      return;
+    }
+
+    // An external activation or deactivation can arrive while setActive is in
+    // progress. Reconcile once more when ownership changed during the call.
+  } while ((self.activationCount > 0) != shouldActivate);
+}
+
+- (void)restoreAudioSessionAfterMediaServicesReset {
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *configuration =
+      [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+  [self lockForConfiguration];
+
+  // The restarted media server no longer owns the previous session state even
+  // when AVAudioSession still reports the cached values. Reapply each value
+  // without comparing it to the getters first.
+  self.isActive = NO;
   NSError *error = nil;
-  if ([self.session setActive:shouldActivate
-                  withOptions:options
-                        error:&error]) {
-    self.isActive = shouldActivate;
-     RTCLogError(@"Did set session active to %d", shouldActivate);
-  } else {
-    RTCLogError(@"Failed to set session active to %d. Error:%@",
-                shouldActivate,
+  if (![self setCategory:configuration.category
+                    mode:configuration.mode
+                 options:configuration.categoryOptions
+                   error:&error]) {
+    RTCLogError(@"Failed to restore category and mode after media-services "
+                @"reset: %@",
                 error.localizedDescription);
   }
+
+  error = nil;
+  if (![self setPreferredSampleRate:configuration.sampleRate error:&error]) {
+    RTCLogError(@"Failed to restore preferred sample rate after media-services "
+                @"reset: %@",
+                error.localizedDescription);
+  }
+
+  error = nil;
+  if (![self setPreferredIOBufferDuration:configuration.ioBufferDuration
+                                    error:&error]) {
+    RTCLogError(@"Failed to restore preferred I/O buffer duration after "
+                @"media-services reset: %@",
+                error.localizedDescription);
+  }
+
+  // Restore the physical session without changing the activation ownership
+  // count. A deactivation racing the reset therefore still wins normally.
+  [self updateAudioSessionAfterEvent];
+
+  if (self.isActive &&
+      [configuration.mode isEqualToString:AVAudioSessionModeVoiceChat]) {
+    error = nil;
+    if (![self setPreferredInputNumberOfChannels:configuration
+                                                     .inputNumberOfChannels
+                                           error:&error]) {
+      RTCLogError(@"Failed to restore preferred input channels after "
+                  @"media-services reset: %@",
+                  error.localizedDescription);
+    }
+
+    error = nil;
+    if (![self setPreferredOutputNumberOfChannels:configuration
+                                                      .outputNumberOfChannels
+                                            error:&error]) {
+      RTCLogError(@"Failed to restore preferred output channels after "
+                  @"media-services reset: %@",
+                  error.localizedDescription);
+    }
+  }
+
+  [self unlockForConfiguration];
 }
 
 - (void)updateCanPlayOrRecord {

--- a/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
+++ b/sdk/objc/components/audio/RTCNativeAudioSessionDelegateAdapter.mm
@@ -72,6 +72,10 @@
 }
 
 - (void)audioSessionMediaServerReset:(RTC_OBJC_TYPE(RTCAudioSession) *)session {
+  // iOS sends this after its media-services process restarts. Existing audio
+  // objects may remain alive while capture and playout stay silent until the
+  // graph is rebuilt.
+  _observer->OnMediaServicesReset();
 }
 
 - (void)audioSession:(RTC_OBJC_TYPE(RTCAudioSession) *)session

--- a/sdk/objc/native/src/audio/audio_session_observer.h
+++ b/sdk/objc/native/src/audio/audio_session_observer.h
@@ -27,6 +27,10 @@ class AudioSessionObserver {
   // Called when audio route changes.
   virtual void OnValidRouteChange() = 0;
 
+  // Called after the media services process restarts.
+  // Implementations can rebuild audio objects invalidated by the reset.
+  virtual void OnMediaServicesReset() {}
+
   // Called when the ability to play or record changes.
   virtual void OnCanPlayOrRecordChange(bool can_play_or_record) = 0;
 

--- a/sdk/objc/unittests/RTCAudioSessionTest.mm
+++ b/sdk/objc/unittests/RTCAudioSessionTest.mm
@@ -21,6 +21,27 @@
 
 #import "components/audio/RTCAudioSession.h"
 #import "components/audio/RTCAudioSessionConfiguration.h"
+#import "components/audio/RTCNativeAudioSessionDelegateAdapter.h"
+
+#include "sdk/objc/native/src/audio/audio_session_observer.h"
+
+namespace {
+
+class TestAudioSessionObserver final : public webrtc::AudioSessionObserver {
+ public:
+  void OnInterruptionBegin() override {}
+  void OnInterruptionEnd(bool should_resume) override {}
+  void OnValidRouteChange() override {}
+  void OnMediaServicesReset() override {
+    did_receive_media_services_reset = true;
+  }
+  void OnCanPlayOrRecordChange(bool can_play_or_record) override {}
+  void OnChangedOutputVolume() override {}
+
+  bool did_receive_media_services_reset = false;
+};
+
+}  // namespace
 
 @interface RTC_OBJC_TYPE (RTCAudioSession)
 (UnitTesting)
@@ -29,17 +50,75 @@
         __weak id<RTC_OBJC_TYPE(RTCAudioSessionDelegate)> > delegates;
 
 - (instancetype)initWithAudioSession:(id)audioSession;
+- (void)handleMediaServicesWereReset:(NSNotification *)notification;
 
 @end
 
 @interface MockAVAudioSession : NSObject
 
 @property(nonatomic, readwrite, assign) float outputVolume;
+@property(nonatomic, readonly) AVAudioSessionCategory lastCategory;
+@property(nonatomic, readonly) AVAudioSessionMode lastMode;
+@property(nonatomic, readonly)
+    AVAudioSessionCategoryOptions lastCategoryOptions;
+@property(nonatomic, readonly) double lastPreferredSampleRate;
+@property(nonatomic, readonly) NSTimeInterval lastPreferredIOBufferDuration;
+@property(nonatomic, readonly) NSInteger lastPreferredInputNumberOfChannels;
+@property(nonatomic, readonly) NSInteger lastPreferredOutputNumberOfChannels;
+@property(nonatomic, readonly) BOOL lastActive;
+@property(nonatomic, readonly) AVAudioSessionSetActiveOptions lastActiveOptions;
+@property(nonatomic, readonly) NSInteger setActiveCallCount;
+@property(nonatomic, copy) void (^setActiveHandler)(BOOL active);
 
 @end
 
 @implementation MockAVAudioSession
 @synthesize outputVolume = _outputVolume;
+
+- (BOOL)setCategory:(AVAudioSessionCategory)category
+               mode:(AVAudioSessionMode)mode
+            options:(AVAudioSessionCategoryOptions)options
+              error:(NSError **)outError {
+  _lastCategory = category;
+  _lastMode = mode;
+  _lastCategoryOptions = options;
+  return YES;
+}
+
+- (BOOL)setPreferredSampleRate:(double)sampleRate error:(NSError **)outError {
+  _lastPreferredSampleRate = sampleRate;
+  return YES;
+}
+
+- (BOOL)setPreferredIOBufferDuration:(NSTimeInterval)duration
+                               error:(NSError **)outError {
+  _lastPreferredIOBufferDuration = duration;
+  return YES;
+}
+
+- (BOOL)setPreferredInputNumberOfChannels:(NSInteger)count
+                                    error:(NSError **)outError {
+  _lastPreferredInputNumberOfChannels = count;
+  return YES;
+}
+
+- (BOOL)setPreferredOutputNumberOfChannels:(NSInteger)count
+                                     error:(NSError **)outError {
+  _lastPreferredOutputNumberOfChannels = count;
+  return YES;
+}
+
+- (BOOL)setActive:(BOOL)active
+      withOptions:(AVAudioSessionSetActiveOptions)options
+            error:(NSError **)outError {
+  _lastActive = active;
+  _lastActiveOptions = options;
+  ++_setActiveCallCount;
+  if (_setActiveHandler) {
+    _setActiveHandler(active);
+  }
+  return YES;
+}
 @end
 
 @interface RTCAudioSessionTestDelegate
@@ -217,12 +296,155 @@
 
 - (void)testAudioSessionActivation {
   RTC_OBJC_TYPE(RTCAudioSession) *audioSession =
-      [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc]
+          initWithAudioSession:[AVAudioSession sharedInstance]];
   EXPECT_EQ(0, audioSession.activationCount);
   [audioSession audioSessionDidActivate:[AVAudioSession sharedInstance]];
   EXPECT_EQ(1, audioSession.activationCount);
   [audioSession audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
   EXPECT_EQ(0, audioSession.activationCount);
+}
+
+- (void)testUnbalancedAudioSessionDeactivationDoesNotUnderflow {
+  RTC_OBJC_TYPE(RTCAudioSession) *audioSession =
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc]
+          initWithAudioSession:[AVAudioSession sharedInstance]];
+  EXPECT_EQ(0, audioSession.activationCount);
+
+  [audioSession audioSessionDidDeactivate:[AVAudioSession sharedInstance]];
+
+  EXPECT_EQ(0, audioSession.activationCount);
+
+  [audioSession audioSessionDidActivate:[AVAudioSession sharedInstance]];
+
+  EXPECT_EQ(1, audioSession.activationCount);
+}
+
+- (void)testMediaServerResetIsForwardedToNativeObserver {
+  TestAudioSessionObserver observer;
+  RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) *adapter =
+      [[RTC_OBJC_TYPE(RTCNativeAudioSessionDelegateAdapter) alloc]
+          initWithObserver:&observer];
+
+  [adapter audioSessionMediaServerReset:[RTC_OBJC_TYPE(RTCAudioSession)
+                                            sharedInstance]];
+
+  EXPECT_TRUE(observer.did_receive_media_services_reset);
+}
+
+- (void)testMediaServicesResetRestoresConfigurationAndActiveState {
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *previousConfiguration =
+      [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *configuration =
+      [[RTC_OBJC_TYPE(RTCAudioSessionConfiguration) alloc] init];
+  configuration.category = AVAudioSessionCategoryPlayAndRecord;
+  configuration.mode = AVAudioSessionModeVoiceChat;
+  configuration.categoryOptions = AVAudioSessionCategoryOptionAllowBluetoothHFP;
+  configuration.sampleRate = 48000;
+  configuration.ioBufferDuration = 0.02;
+  configuration.inputNumberOfChannels = 1;
+  configuration.outputNumberOfChannels = 1;
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:configuration];
+
+  MockAVAudioSession *mockAVAudioSession = [[MockAVAudioSession alloc] init];
+  RTC_OBJC_TYPE(RTCAudioSession) *audioSession =
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc]
+          initWithAudioSession:mockAVAudioSession];
+
+  [audioSession audioSessionDidActivate:(AVAudioSession *)mockAVAudioSession];
+  [audioSession handleMediaServicesWereReset:nil];
+
+  EXPECT_EQ(1, audioSession.activationCount);
+  EXPECT_TRUE(audioSession.isActive);
+  EXPECT_EQ(configuration.category, mockAVAudioSession.lastCategory);
+  EXPECT_EQ(configuration.mode, mockAVAudioSession.lastMode);
+  EXPECT_EQ(configuration.categoryOptions,
+            mockAVAudioSession.lastCategoryOptions);
+  EXPECT_EQ(configuration.sampleRate,
+            mockAVAudioSession.lastPreferredSampleRate);
+  EXPECT_EQ(configuration.ioBufferDuration,
+            mockAVAudioSession.lastPreferredIOBufferDuration);
+  EXPECT_EQ(configuration.inputNumberOfChannels,
+            mockAVAudioSession.lastPreferredInputNumberOfChannels);
+  EXPECT_EQ(configuration.outputNumberOfChannels,
+            mockAVAudioSession.lastPreferredOutputNumberOfChannels);
+  EXPECT_TRUE(mockAVAudioSession.lastActive);
+  EXPECT_EQ(0u, mockAVAudioSession.lastActiveOptions);
+  EXPECT_EQ(1, mockAVAudioSession.setActiveCallCount);
+
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:previousConfiguration];
+}
+
+- (void)testMediaServicesResetKeepsSessionInactiveWithoutActivationOwner {
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *previousConfiguration =
+      [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *configuration =
+      [[RTC_OBJC_TYPE(RTCAudioSessionConfiguration) alloc] init];
+  configuration.category = AVAudioSessionCategoryPlayAndRecord;
+  configuration.mode = AVAudioSessionModeVoiceChat;
+  configuration.categoryOptions = 0;
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:configuration];
+
+  MockAVAudioSession *mockAVAudioSession = [[MockAVAudioSession alloc] init];
+  RTC_OBJC_TYPE(RTCAudioSession) *audioSession =
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc]
+          initWithAudioSession:mockAVAudioSession];
+
+  [audioSession handleMediaServicesWereReset:nil];
+
+  EXPECT_EQ(0, audioSession.activationCount);
+  EXPECT_FALSE(audioSession.isActive);
+  EXPECT_FALSE(mockAVAudioSession.lastActive);
+  EXPECT_EQ(AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation,
+            mockAVAudioSession.lastActiveOptions);
+  EXPECT_EQ(1, mockAVAudioSession.setActiveCallCount);
+
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:previousConfiguration];
+}
+
+- (void)testMediaServicesResetReconcilesDeactivationDuringRestore {
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *previousConfiguration =
+      [RTC_OBJC_TYPE(RTCAudioSessionConfiguration) webRTCConfiguration];
+  RTC_OBJC_TYPE(RTCAudioSessionConfiguration) *configuration =
+      [[RTC_OBJC_TYPE(RTCAudioSessionConfiguration) alloc] init];
+  configuration.category = AVAudioSessionCategoryPlayAndRecord;
+  configuration.mode = AVAudioSessionModeVoiceChat;
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:configuration];
+
+  MockAVAudioSession *mockAVAudioSession = [[MockAVAudioSession alloc] init];
+  RTC_OBJC_TYPE(RTCAudioSession) *audioSession =
+      [[RTC_OBJC_TYPE(RTCAudioSession) alloc]
+          initWithAudioSession:mockAVAudioSession];
+  [audioSession audioSessionDidActivate:(AVAudioSession *)mockAVAudioSession];
+
+  __block BOOL didDeactivate = NO;
+  __weak RTC_OBJC_TYPE(RTCAudioSession) *weakAudioSession = audioSession;
+  __weak MockAVAudioSession *weakMockAVAudioSession = mockAVAudioSession;
+  mockAVAudioSession.setActiveHandler = ^(BOOL active) {
+    if (active && !didDeactivate) {
+      didDeactivate = YES;
+      [weakAudioSession
+          audioSessionDidDeactivate:(AVAudioSession *)weakMockAVAudioSession];
+    }
+  };
+
+  [audioSession handleMediaServicesWereReset:nil];
+  mockAVAudioSession.setActiveHandler = nil;
+
+  EXPECT_EQ(0, audioSession.activationCount);
+  EXPECT_FALSE(audioSession.isActive);
+  EXPECT_FALSE(mockAVAudioSession.lastActive);
+  EXPECT_EQ(AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation,
+            mockAVAudioSession.lastActiveOptions);
+  EXPECT_EQ(2, mockAVAudioSession.setActiveCallCount);
+
+  [RTC_OBJC_TYPE(RTCAudioSessionConfiguration)
+      setWebRTCConfiguration:previousConfiguration];
 }
 
 // TODO(b/298960678): Fix crash when running the test on simulators.


### PR DESCRIPTION
## Summary

- Restore the `AVAudioSession` configuration and active state after iOS media services reset, using current activation ownership and reconciling concurrent activation changes.
- Forward the reset notification to native audio observers and rebuild the `AudioEngineDevice` graph so capture and playout can resume.
- Prevent unmatched deactivation callbacks from underflowing the activation count and corrupting subsequent recovery decisions.

## Impact

Addresses [IOS-1961](https://linear.app/stream/issue/IOS-1961/bugmediaservices-teardown-issue), where a call remains connected but becomes bidirectionally silent after the iOS media-services process restarts.

This change restores WebRTC’s audio session and engine after iOS reports the reset. It does not prevent or identify the underlying OS process restart.

Inactive sessions remain inactive, and a deactivation received during recovery is reconciled before recovery completes. There are no SDK-facing API changes.

## Validation

- Focused `RTCAudioSessionTest` XCTest run: 5 passed, 0 failed.
  - `testMediaServerResetIsForwardedToNativeObserver`
  - `testUnbalancedAudioSessionDeactivationDoesNotUnderflow`
  - `testMediaServicesResetRestoresConfigurationAndActiveState`
  - `testMediaServicesResetKeepsSessionInactiveWithoutActivationOwner`
  - `testMediaServicesResetReconcilesDeactivationDuringRestore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio recovery after iOS media services restart.
  - Restores audio configuration, recording and playback state, and channel settings when possible.
  - Preserves inactive audio sessions correctly during recovery.
  - Improved audio-session activation handling to prevent state inconsistencies and retry when needed.
  - Added safeguards against unmatched deactivation calls that could cause activation tracking errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->