### PR TITLE
[Fix] Catch SecurityException in Camera2Session async callbacks

### DIFF
--- a/sdk/android/src/java/org/webrtc/Camera2Session.java
+++ b/sdk/android/src/java/org/webrtc/Camera2Session.java
@@ -122,7 +122,9 @@ class Camera2Session implements CameraSession {
       try {
         camera.createCaptureSession(
             Arrays.asList(surface), new CaptureSessionCallback(), cameraThreadHandler);
-      } catch (CameraAccessException e) {
+      } catch (CameraAccessException | SecurityException | IllegalStateException e) {
+        // The camera service rejects calls when the owning client record no longer matches
+        // this process, or when the device was closed underneath this callback.
         reportError("Failed to create capture session. " + e);
         return;
       }
@@ -173,7 +175,9 @@ class Camera2Session implements CameraSession {
         captureRequestBuilder.addTarget(surface);
         session.setRepeatingRequest(
             captureRequestBuilder.build(), new CameraCaptureCallback(), cameraThreadHandler);
-      } catch (CameraAccessException e) {
+      } catch (CameraAccessException | SecurityException | IllegalStateException e) {
+        // The camera service rejects calls when the owning client record no longer matches
+        // this process, or when the device was closed underneath this callback.
         reportError("Failed to start capture request. " + e);
         return;
       }

--- a/sdk/android/src/java/org/webrtc/Camera2Session.java
+++ b/sdk/android/src/java/org/webrtc/Camera2Session.java
@@ -123,8 +123,6 @@ class Camera2Session implements CameraSession {
         camera.createCaptureSession(
             Arrays.asList(surface), new CaptureSessionCallback(), cameraThreadHandler);
       } catch (CameraAccessException | SecurityException | IllegalStateException e) {
-        // The camera service rejects calls when the owning client record no longer matches
-        // this process, or when the device was closed underneath this callback.
         reportError("Failed to create capture session. " + e);
         return;
       }
@@ -176,8 +174,6 @@ class Camera2Session implements CameraSession {
         session.setRepeatingRequest(
             captureRequestBuilder.build(), new CameraCaptureCallback(), cameraThreadHandler);
       } catch (CameraAccessException | SecurityException | IllegalStateException e) {
-        // The camera service rejects calls when the owning client record no longer matches
-        // this process, or when the device was closed underneath this callback.
         reportError("Failed to start capture request. " + e);
         return;
       }


### PR DESCRIPTION
Fixes a production crash reported by a customer (209 events / 139 users / 90 days):

```
Fatal Exception: java.lang.SecurityException: checkPidStatus:2229: Attempt to use camera from a different process than original client
    at android.hardware.camera2.impl.CameraDeviceImpl.createCaptureRequest(CameraDeviceImpl.java:997)
    at org.webrtc.Camera2Session$CaptureSessionCallback.onConfigured(Camera2Session.java:162)
```

When camera access is revoked mid-session (app loses foreground visibility, privacy toggle, permission revocation), the camera service resets the stored client PID to lock the client out, so the app's own subsequent calls fail with an unchecked `SecurityException`. `onOpened` and `onConfigured` caught only `CameraAccessException`, so it escaped the camera-thread callback and killed the process.

Widened both catches to `CameraAccessException | SecurityException | IllegalStateException`, matching what `openCamera()` already does. Errors now route through the existing `reportError()` path, so capture stops cleanly and the call survives. No change on non-throwing paths.

Not fixed by a milestone bump — this file is byte-identical from `m125.4` through `main`, and in LiveKit, Signal and Telegram too. The `SecurityException` catch in `openCamera()` doesn't help: it is already present in `m125.4`, and `onConfigured` runs on the Looper after that stack frame unwound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
