### PR TITLE
[Fix] Reconfigure iOS audio after post-reset CallKit activation

### DIFF
--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -505,6 +505,7 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
 
   // CallKit may reactivate the audio session after the media server restarts.
   // Rebuild once more after that activation so the graph uses the new I/O unit.
+  // Keep recovery pending after a failed rebuild so a later activation retries.
   std::atomic<bool> should_reconfigure_after_media_services_reset_{false};
 
   bool IsMicrophonePermissionGranted();
@@ -515,7 +516,8 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   int32_t ApplyManualEngineState(EngineStateUpdate& state);
 
   // AudioEngine observer methods. May be called from any thread.
-  void ReconfigureEngine();
+  void ReconfigureEngine(
+      bool restore_media_services_recovery_on_failure = false);
 
   // Stereo Playout helpers
   int32_t ResolveStereoPlayoutAvailability(const EngineState& state, bool* available) const;

--- a/modules/audio_device/audio_engine_device.h
+++ b/modules/audio_device/audio_engine_device.h
@@ -17,6 +17,7 @@
 #ifndef SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 #define SDK_OBJC_NATIVE_SRC_AUDIO_AUDIO_DEVICE_AUDIOENGINE_H_
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -501,6 +502,10 @@ class AudioEngineDevice : public AudioDeviceModule, public AudioSessionObserver 
   };
 
   EngineState engine_state_ RTC_GUARDED_BY(thread_);
+
+  // CallKit may reactivate the audio session after the media server restarts.
+  // Rebuild once more after that activation so the graph uses the new I/O unit.
+  std::atomic<bool> should_reconfigure_after_media_services_reset_{false};
 
   bool IsMicrophonePermissionGranted();
   void ResetEngineState();

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -631,13 +631,20 @@ void AudioEngineDevice::OnInterruptionEnd(bool should_resume) {
   LOGI() << "OnInterruptionEnd should_resume: " << should_resume;
 
   RTC_DCHECK(thread_);
-  thread_->PostTask(SafeTask(safety_, [this] {
+  thread_->PostTask(SafeTask(safety_, [this, should_resume] {
     int32_t result = this->ModifyEngineState([](EngineState state) -> EngineState {
       state.is_interrupted = false;
       return state;
     });
     if (result != 0) {
       LOGE() << "Failed to update engine state for interruption end, error: " << result;
+    }
+
+    if (should_resume &&
+        this->should_reconfigure_after_media_services_reset_.exchange(false)) {
+      LOGI() << "Reconfiguring after media-services reset and audio-session "
+                "reactivation";
+      this->ReconfigureEngine();
     }
   }));
 }
@@ -658,6 +665,7 @@ void AudioEngineDevice::OnMediaServicesReset() {
   // A media-services reset invalidates AVAudioEngine and its nodes even though
   // WebRTC still considers playout and recording started. ReconfigureEngine
   // rebuilds the graph and restores their prior state.
+  should_reconfigure_after_media_services_reset_.store(true);
   ReconfigureEngine();
 }
 

--- a/modules/audio_device/audio_engine_device.mm
+++ b/modules/audio_device/audio_engine_device.mm
@@ -638,13 +638,15 @@ void AudioEngineDevice::OnInterruptionEnd(bool should_resume) {
     });
     if (result != 0) {
       LOGE() << "Failed to update engine state for interruption end, error: " << result;
+      return;
     }
 
     if (should_resume &&
         this->should_reconfigure_after_media_services_reset_.exchange(false)) {
       LOGI() << "Reconfiguring after media-services reset and audio-session "
                 "reactivation";
-      this->ReconfigureEngine();
+      this->ReconfigureEngine(
+          /*restore_media_services_recovery_on_failure=*/true);
     }
   }));
 }
@@ -1595,48 +1597,58 @@ int32_t AudioEngineDevice::InitRecordingPersistentMode(bool* enabled) {
 // ----------------------------------------------------------------------------------------------------
 // Private - Engine Related
 
-void AudioEngineDevice::ReconfigureEngine() {
+void AudioEngineDevice::ReconfigureEngine(
+    bool restore_media_services_recovery_on_failure) {
   LOGI() << "ReconfigureEngine";
 
   // TODO: More optimizations
   // We only need to re-attach the input / output nodes with updated sample rate etc.
 
-  thread_->PostTask(SafeTask(safety_, [this] {
-    RTC_DCHECK_RUN_ON(thread_);
+  thread_->PostTask(
+      SafeTask(safety_, [this, restore_media_services_recovery_on_failure] {
+        RTC_DCHECK_RUN_ON(thread_);
 
-    // Snapshot on the device thread so stop and availability updates are
-    // ordered before or after the complete recovery transition.
-    EngineState current_state = this->engine_state_;
+        // Snapshot on the device thread so stop and availability updates are
+        // ordered before or after the complete recovery transition.
+        EngineState current_state = this->engine_state_;
 
-    // Re-configure is only for device mode
-    if (current_state.render_mode != RenderMode::Device) return;
+        // Re-configure is only for device mode
+        if (current_state.render_mode != RenderMode::Device) return;
 
-    EngineState shutdown_state = this->engine_state_;
-    shutdown_state.input_enabled = false;
-    shutdown_state.input_running = false;
-    shutdown_state.output_enabled = false;
-    shutdown_state.output_running = false;
+        EngineState shutdown_state = this->engine_state_;
+        shutdown_state.input_enabled = false;
+        shutdown_state.input_running = false;
+        shutdown_state.output_enabled = false;
+        shutdown_state.output_running = false;
 
-    int32_t shutdown_result =
-        this->ModifyEngineState([shutdown_state](EngineState state) -> EngineState {
-          return shutdown_state;  // Shutdown engine
-        });
+        int32_t shutdown_result = this->ModifyEngineState(
+            [shutdown_state](EngineState state) -> EngineState {
+              return shutdown_state;  // Shutdown engine
+            });
 
-    if (shutdown_result != 0) {
-      LOGE() << "ReconfigureEngine: Failed to shutdown engine, error: " << shutdown_result;
-      return;
-    }
+        if (shutdown_result != 0) {
+          LOGE() << "ReconfigureEngine: Failed to shutdown engine, error: "
+                 << shutdown_result;
+          if (restore_media_services_recovery_on_failure) {
+            should_reconfigure_after_media_services_reset_.store(true);
+          }
+          return;
+        }
 
-    int32_t recover_result =
-        this->ModifyEngineState([current_state](EngineState state) -> EngineState {
-          return current_state;  // Recover engine state
-        });
+        int32_t recover_result = this->ModifyEngineState(
+            [current_state](EngineState state) -> EngineState {
+              return current_state;  // Recover engine state
+            });
 
-    if (recover_result != 0) {
-      LOGE() << "ReconfigureEngine: Failed to recover engine state, error: " << recover_result;
-      // We're in a bad state now, could consider more recovery options here
-    }
-  }));
+        if (recover_result != 0) {
+          LOGE() << "ReconfigureEngine: Failed to recover engine state, error: "
+                 << recover_result;
+          if (restore_media_services_recovery_on_failure) {
+            should_reconfigure_after_media_services_reset_.store(true);
+          }
+          // We're in a bad state now, could consider more recovery options here
+        }
+      }));
 }
 
 bool AudioEngineDevice::IsMicrophonePermissionGranted() {

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -47,6 +47,39 @@
     }                                             \
   } while (false)
 
+- (void)testMediaServicesRecoveryReconfiguresAfterInterruptionEnd {
+  RTC_OBJC_TYPE(RTCPeerConnectionFactory) *factory =
+      [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc]
+          initWithAudioDeviceModuleType:RTC_OBJC_TYPE(
+                                            RTCAudioDeviceModuleTypeAudioEngine)
+                  bypassVoiceProcessing:NO
+                         encoderFactory:nil
+                         decoderFactory:nil
+                  audioProcessingModule:nil];
+  XCTAssertNotNil(factory.audioDeviceModule);
+
+  XCTestExpectation *reconfiguredTwice =
+      [self expectationWithDescription:@"audio engine reconfigured twice"];
+  reconfiguredTwice.expectedFulfillmentCount = 2;
+  RTC_OBJC_TYPE(RTCCallbackLogger) *logger =
+      [[RTC_OBJC_TYPE(RTCCallbackLogger) alloc] init];
+  logger.severity = RTCLoggingSeverityInfo;
+  [logger startWithMessageAndSeverityHandler:^(NSString *message,
+                                               RTCLoggingSeverity severity) {
+    if ([message containsString:@"AudioEngineDevice::ReconfigureEngine"]) {
+      [reconfiguredTwice fulfill];
+    }
+  }];
+
+  RTC_OBJC_TYPE(RTCAudioSession) *session =
+      [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
+  [session notifyMediaServicesWereReset];
+  [session notifyDidEndInterruptionWithShouldResumeSession:YES];
+
+  [self waitForExpectations:@[ reconfiguredTwice ] timeout:1.0];
+  [logger stop];
+}
+
 - (void)testAudioEngineInputRenderContextIgnoresLateCallbackAfterInvalidation {
   auto audioDeviceBuffer = std::make_shared<webrtc::AudioDeviceBuffer>(
       webrtc::CreateEnvironment());

--- a/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
+++ b/sdk/objc/unittests/RTCPeerConnectionFactoryAudioEngine_xctest.mm
@@ -8,6 +8,7 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
 #include <memory>
@@ -77,6 +78,75 @@
   [session notifyDidEndInterruptionWithShouldResumeSession:YES];
 
   [self waitForExpectations:@[ reconfiguredTwice ] timeout:1.0];
+  [logger stop];
+}
+
+- (void)
+    testMediaServicesRecoveryRemainsPendingWhenDeferredReconfigurationFails {
+  RTC_OBJC_TYPE(RTCPeerConnectionFactory) *factory =
+      [[RTC_OBJC_TYPE(RTCPeerConnectionFactory) alloc]
+          initWithAudioDeviceModuleType:RTC_OBJC_TYPE(
+                                            RTCAudioDeviceModuleTypeAudioEngine)
+                  bypassVoiceProcessing:NO
+                         encoderFactory:nil
+                         decoderFactory:nil
+                  audioProcessingModule:nil];
+  RTC_OBJC_TYPE(RTCAudioDeviceModule) *audioDeviceModule =
+      factory.audioDeviceModule;
+
+  RTC_OBJC_TYPE(RTCMediaConstraints) *constraints =
+      [[RTC_OBJC_TYPE(RTCMediaConstraints) alloc]
+          initWithMandatoryConstraints:nil
+                   optionalConstraints:nil];
+  RTC_OBJC_TYPE(RTCPeerConnection) *peerConnection = [factory
+      peerConnectionWithConfiguration:[[RTC_OBJC_TYPE(RTCConfiguration) alloc]
+                                          init]
+                          constraints:constraints
+                             delegate:nil];
+  XCTAssertNotNil(peerConnection);
+  XCTAssertEqual(0, [audioDeviceModule initPlayout]);
+
+  id observer =
+      OCMProtocolMock(@protocol(RTC_OBJC_TYPE(RTCAudioDeviceModuleDelegate)));
+  OCMStub([observer audioDeviceModule:[OCMArg any]
+                    willReleaseEngine:[OCMArg any]])
+      .andReturn(-1);
+  audioDeviceModule.observer = observer;
+
+  XCTestExpectation *initialFailures =
+      [self expectationWithDescription:@"initial reconfiguration failures"];
+  initialFailures.expectedFulfillmentCount = 2;
+  XCTestExpectation *retryFailure =
+      [self expectationWithDescription:@"retried reconfiguration failure"];
+  __block NSUInteger failureCount = 0;
+  RTC_OBJC_TYPE(RTCCallbackLogger) *logger =
+      [[RTC_OBJC_TYPE(RTCCallbackLogger) alloc] init];
+  logger.severity = RTCLoggingSeverityError;
+  [logger startWithMessageAndSeverityHandler:^(NSString *message,
+                                               RTCLoggingSeverity severity) {
+    if ([message
+            containsString:@"ReconfigureEngine: Failed to shutdown engine"]) {
+      failureCount++;
+      if (failureCount <= 2) {
+        [initialFailures fulfill];
+      } else if (failureCount == 3) {
+        [retryFailure fulfill];
+      }
+    }
+  }];
+
+  RTC_OBJC_TYPE(RTCAudioSession) *session =
+      [RTC_OBJC_TYPE(RTCAudioSession) sharedInstance];
+  [session notifyMediaServicesWereReset];
+  [session notifyDidEndInterruptionWithShouldResumeSession:YES];
+  [self waitForExpectations:@[ initialFailures ] timeout:1.0];
+
+  [session notifyDidEndInterruptionWithShouldResumeSession:YES];
+  [self waitForExpectations:@[ retryFailure ] timeout:1.0];
+
+  audioDeviceModule.observer = nil;
+  XCTAssertEqual(0, [audioDeviceModule reset]);
+  [peerConnection close];
   [logger stop];
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #106 for [IOS-1961](https://linear.app/stream/issue/IOS-1961/bugmediaservices-teardown-issue).

When media services reset while CallKit controls the audio session, the immediate `AVAudioEngine` rebuild can occur before `AVAudioSession` is reactivated. The rebuilt graph can therefore remain attached to an unusable I/O unit, leaving capture and playout silent.

This change:

- Records that a media-services reset requires another engine rebuild after audio-session reactivation.
- Atomically consumes that pending recovery when an interruption ends with `should_resume`.
- Reconfigures the engine after CallKit reactivates the audio session.
- Adds regression coverage verifying reconfiguration at both reset and reactivation.

## Impact

- Restores audio after the media-services reset and CallKit lifecycle reproduced on a physical device.
- Retains the immediate reset recovery while adding one deferred rebuild after a resumable activation.
- Introduces no public API changes.

## Validation

- [x] Built the local iOS XCFramework and ran it in the SDK app on a physical device.
- [x] Reproduced the original CallKit, background, PiP, media-services reset, and foreground sequence; audio recovered.
- [x] Device logs showed `OnMediaServicesReset` followed by the immediate `ReconfigureEngine`, then `OnInterruptionEnd should_resume: 1` and a second `ReconfigureEngine` after audio-session reactivation.
- [x] Post-recovery logs reported non-silent audio levels.
- [x] `git diff --check origin/main`
- [ ] Run the focused XCTest containing `testMediaServicesRecoveryReconfiguresAfterInterruptionEnd`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio recovery after media services are reset.
  * Audio is now reconfigured automatically when the audio session resumes after an interruption.
  * Deferred recovery now retries after temporary reconfiguration failures.

* **Tests**
  * Added coverage validating successful and repeated audio-engine recovery following media-services resets and interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->