### PR TITLE
[Fix] Don't abort the process when ADM Init() fails

### DIFF
--- a/media/engine/adm_helpers.cc
+++ b/media/engine/adm_helpers.cc
@@ -36,7 +36,11 @@ namespace adm_helpers {
 void Init(AudioDeviceModule* adm) {
   RTC_DCHECK(adm);
 
-  RTC_CHECK_EQ(0, adm->Init()) << "Failed to initialize the ADM.";
+  auto result = adm->Init();
+  if (result != 0) {
+    RTC_LOG(LS_ERROR) << "Failed to initialize the ADM: " << result;
+    return;
+  }
 
   // Playout device.
   {


### PR DESCRIPTION
`adm_helpers::Init()` used `RTC_CHECK_EQ(0, adm->Init())`, which is fatal in release builds. It runs from `WebRtcVoiceEngine::Init()` during PeerConnectionFactory setup, so a failed audio-device init killed the whole app instead of degrading to a call without audio.

Reachable on Android, where `AudioDeviceModule::Init()` returns `-1` if the playout or recording device fails to initialize. Not reachable on iOS — `AudioDeviceIOS::Init()` always returns `InitStatus::OK`.